### PR TITLE
JWT is integrated into gateway

### DIFF
--- a/apps/data_channel_gateway/src/client/client.ts
+++ b/apps/data_channel_gateway/src/client/client.ts
@@ -45,10 +45,18 @@ export class UrlqGraphqlClient {
   }
 
   async validateToken(token: string) {
+    console.log(`validating token: ${token}`)
     const query = gql`
       query {
-        validate(token:"")
+        validate(token:"${token}")
       }
     `
+    console.log(query)
+
+    const response  = await this.client.query(query, {}).toPromise();
+
+    console.log(response)
+
+    return response.data
   }
 }


### PR DESCRIPTION
Gateway now verifies JWT before the /graphql endpoint so the server will no respond without good creds
