### PR TITLE
Update tests and refine data channel access

### DIFF
--- a/apps/data_channel_gateway/src/index.ts
+++ b/apps/data_channel_gateway/src/index.ts
@@ -124,7 +124,6 @@ app.use("/graphql", async (ctx) => {
     data channels returned: [ dc1, dc3 ]
    */
   const allDataChannels = await client.allDataChannelsByClaims(
-      //JSON.parse(ctx.req.header('x-catalyst-claims') as string)
       ctx.get('claims') ?? []
   );
 


### PR DESCRIPTION
Modified the data channel gateway tests to better reflect actual use cases. Also introduced changes in the data channel registrar to refine data channel access control by considering the 'accessSwitch' property. Each data channel will only be accessible if its accessSwitch value is 1.