### PR TITLE
jwt tests include using do for no auth

### DIFF
--- a/apps/authx_token_api/src/env.d.ts
+++ b/apps/authx_token_api/src/env.d.ts
@@ -1,4 +1,9 @@
 import {JWTKeyProvider} from "./durable_object_security_module"
+import AuthzedWorker from "../../authx_authzed_api/src"
+import UserCredsCacheWorker from "../../user_credentials_cache/src"
+
 interface Env {
 	KEY_PROVIDER: DurableObjectNamespace<JWTKeyProvider>;
+	AUTHZED: Service<AuthzedWorker>
+	USERCACHE: Service<UserCredsCacheWorker>
 }

--- a/apps/authx_token_api/src/index.ts
+++ b/apps/authx_token_api/src/index.ts
@@ -3,7 +3,7 @@ import { JWTKeyProvider } from './durable_object_security_module';
 import { WorkerEntrypoint } from 'cloudflare:workers';
 import { Env } from './env';
 export { JWTKeyProvider } from './durable_object_security_module';
-import {  JWTSigningRequest } from '../../../packages/schema_zod';
+import { JWTSigningRequest, JWTSigningResponse, Token, User } from '../../../packages/schema_zod';
 type Bindings = {
 	// @ts-ignore
 	KEY_PROVIDER: DurableObjectNamespace<JWTKeyProvider>;
@@ -16,16 +16,53 @@ export default class JWTWorker extends WorkerEntrypoint<Env> {
 		return stub.getPublicKey();
 	}
 
-	async rotateKey(keyNamespace: string = 'default') {
+	// rotate requires a token to ensure this is only done by platform admins
+	async rotateKey(keyNamespace: string = 'default', token: Token) {
 		const id = this.env.KEY_PROVIDER.idFromName(keyNamespace);
 		const stub = this.env.KEY_PROVIDER.get(id);
 		return stub.rotateKey();
 	}
 
-	async signJWT(jwtRequest: JWTSigningRequest, expiresIn: number, keyNamespace: string = 'default') {
+	// ensure all claims in the request are valid before signing
+	async signJWT(jwtRequest: JWTSigningRequest, expiresIn: number, token: Token, keyNamespace: string = 'default') {
+		if (!token.cfToken) {
+			console.error("need a cf token to sign a JWT")
+			return JWTSigningResponse.parse({
+				success: false,
+				error: "catalyst did not recieve a user-based token"
+			})
+		}
+
+		const userParse = User.safeParse(await this.env.USERCACHE.getUser(token.cfToken))
+		if (!userParse.success) {
+			console.log(userParse.error)
+			return JWTSigningResponse.parse({
+				success: false,
+				error: "catalyst is unable to verify user"
+			})
+		}
+		const failedClaimsChecks = (await Promise.all(jwtRequest.claims.map(async (claim) => {
+			return {
+				claim: claim,
+				check: await this.env.AUTHZED.canReadFromDataChannel(claim, userParse.data.userId)
+			}
+		}))).filter(check => {
+			return !check.check
+		})
+		if (failedClaimsChecks.length > 0) {
+			console.log("user is not authorized for all claims")
+			return JWTSigningResponse.parse({
+				success: false,
+				error: "catalyst is unable to validate user to all claims"
+			})
+		}
 		const id = this.env.KEY_PROVIDER.idFromName(keyNamespace);
 		const stub = this.env.KEY_PROVIDER.get(id);
-		return stub.signJWT(jwtRequest, expiresIn);
+		const jwt = await stub.signJWT(jwtRequest, expiresIn);
+		return JWTSigningResponse.parse({
+			success: true,
+			token: jwt.token
+		})
 	}
 
 	async validateToken(token: string, keyNamespace: string = 'default') {

--- a/apps/authx_token_api/wrangler.toml
+++ b/apps/authx_token_api/wrangler.toml
@@ -3,6 +3,11 @@ compatibility_date = "2024-04-05"
 compatibility_flags = [ "nodejs_compat" ]
 main = "src/index.ts"
 
+services = [
+	{ binding = "AUTHZED", service = "authx_authzed_api"},
+	{ binding = "USERCACHE", service = "user_credentials_cache"}
+]
+
 [dev]
 ip = "localhost"
 port = 5052

--- a/apps/data_channel_gateway/tests/env.d.ts
+++ b/apps/data_channel_gateway/tests/env.d.ts
@@ -3,7 +3,7 @@ declare module "cloudflare:test" {
 
   import RegistrarWorker, {Registrar} from '@catalyst/data_channel_registrar/src/worker';
   import AuthzedWorker from "@catalyst/authx_authzed_api/src";
-  import JWTWorker from "@catalyst/authx_token_api/src";
+  import JWTWorker, {JWTKeyProvider} from "@catalyst/authx_token_api/src";
 
 // @ts-expect-error Env is extended (but not exported) as a part of the vitest integration
   interface ProvidedEnv extends Env {
@@ -14,5 +14,6 @@ declare module "cloudflare:test" {
     DATA_CHANNEL_REGISTRAR_DO: DurableObjectNamespace<Registrar>
     AUTHX_AUTHZED_API: Service<AuthzedWorker>
     AUTHX_TOKEN_API: Service<JWTWorker>
+    JWT_TOKEN_DO: DurableObjectNamespace<JWTKeyProvider>
   }
 }

--- a/apps/data_channel_gateway/tests/jwt.spec.ts
+++ b/apps/data_channel_gateway/tests/jwt.spec.ts
@@ -29,16 +29,18 @@ describe("jwt integration tests", () => {
       entity: "testuser",
       claims: ["testclaim"],
     }
-    const tokenResp = await env.AUTHX_TOKEN_API.signJWT(jwtRequest)
-    console.log(tokenResp)
-    const validateResp = await env.AUTHX_TOKEN_API.validateToken(tokenResp.token)
+    const jwtDoId = env.JWT_TOKEN_DO.idFromName("default")
+    const jwtStub = env.JWT_TOKEN_DO.get(jwtDoId)
+    const jwtToken = await jwtStub.signJWT(jwtRequest, 1000000000)
+    console.log(jwtToken)
+    const validateResp = await env.AUTHX_TOKEN_API.validateToken(jwtToken.token)
     delete validateResp["Symbol(dispose)"]
     console.log(validateResp)
     expect(validateResp.claims[0]).toBe( 'testclaim' )
     expect(validateResp.valid).toBeTruthy()
     expect(validateResp.entity).toBe("testuser")
 
-    const invalid = await env.AUTHX_TOKEN_API.validateToken(tokenResp.token + "makebad")
+    const invalid = await env.AUTHX_TOKEN_API.validateToken(jwtToken.token + "makebad")
     expect(invalid.valid).toBeFalsy()
   })
 })

--- a/apps/data_channel_gateway/vitest.config.ts
+++ b/apps/data_channel_gateway/vitest.config.ts
@@ -61,6 +61,10 @@ export default defineWorkersProject(async () => {
               DATA_CHANNEL_REGISTRAR_DO: {
                 className: "Registrar",
                 scriptName: "data_channel_registrar"
+              },
+              JWT_TOKEN_DO: {
+                className: "JWTKeyProvider",
+                scriptName: "authx_token_api"
               }
             },
             /*d1Databases: {

--- a/packages/schema_zod/types.ts
+++ b/packages/schema_zod/types.ts
@@ -95,3 +95,21 @@ export const JWTSigningRequest = z.object({
 })
 
 export type JWTSigningRequest = z.infer<typeof JWTSigningRequest>
+
+export const JWTSigningSuccess = z.object({
+  success: z.literal(true),
+  token: z.string()
+})
+
+export const JWTSigningError = z.object({
+  success: z.literal(false),
+  error: z.string()
+})
+
+export const JWTSigningResponse = z.discriminatedUnion("success",
+  [
+    JWTSigningSuccess,
+    JWTSigningError
+  ])
+
+export type JWTSigningResponse = z.infer<typeof JWTSigningResponse>


### PR DESCRIPTION
### TL;DR

Added AuthzedWorker and UserCredsCacheWorker services to the environment.

Updated tests to now use DO when auth mocks are not avaible.

### What changed?

- Added AuthzedWorker and UserCredsCacheWorker services to the environment.
- Updated signJWT and validateToken methods in JWTWorker.

### How to test?

- Ensure the new services are properly initialized in the environment.
- Test the signJWT method with valid and invalid tokens.
- Test the validateToken method with different scenarios.

### Why make this change?

To enhance authentication and authorization functionality by introducing new services and improving existing JWT signing and validation methods.

---

