### PR TITLE
Org Admins are Data Custodians

### DIFF
--- a/apps/catalyst-ui/app/api/v1/user/sync/route.ts
+++ b/apps/catalyst-ui/app/api/v1/user/sync/route.ts
@@ -27,6 +27,13 @@ export async function GET(request: NextRequest) {
           user.orgId,
           user.userId
         );
+        const custResp =
+          // @ts-ignore
+          await getRequestContext().env.AUTHX_AUTHZED_API.addDataCustodianToOrg(
+            user.orgId,
+            user.userId
+          );
+        console.log({ custResp });
       }
     } else {
       return Response.json({ error: "no user found" });


### PR DESCRIPTION
### TL;DR

This PR introduces a change to the user sync route which includes the addition of a Data Custodian to an organization during the sync process.

### What changed?

Within the GET function in the user sync route file, a new functionality has been added that allows for a Data Custodian to be added to an organization. This change involves calling the 'addDataCustodianToOrg' function from the AUTHX_AUTHZED_API with the user's orgId and userId as arguments.

