### PR TITLE
fixed JWKS/export and validation issue

### DIFF
--- a/apps/authx_token_api/package.json
+++ b/apps/authx_token_api/package.json
@@ -17,6 +17,7 @@
 		"@cloudflare/workers-types": "^4.20240405.0",
 		"@types/uuid": "^9.0.8",
 		"base64url": "^3.0.1",
+		"bun": "^1.1.7",
 		"jose": "^5.2.4",
 		"typescript": "^5.4.5",
 		"uuid": "^9.0.1",

--- a/apps/authx_token_api/src/index.ts
+++ b/apps/authx_token_api/src/index.ts
@@ -19,7 +19,7 @@ export default class JWTWorker extends WorkerEntrypoint<Env> {
 	async getPublicKeyJWK(keyNamespace: string = 'default') {
 		const id = this.env.KEY_PROVIDER.idFromName(keyNamespace);
 		const stub = this.env.KEY_PROVIDER.get(id);
-		return await stub.getPublickKeyJWK();
+		return await stub.getJWKS();
 	}
 
 	// rotate requires a token to ensure this is only done by platform admins

--- a/apps/authx_token_api/src/keystate.ts
+++ b/apps/authx_token_api/src/keystate.ts
@@ -1,0 +1,81 @@
+import { generateKeyPair, jwtVerify, KeyLike, exportSPKI, importSPKI, SignJWT, exportJWK, importJWK, JWK, createLocalJWKSet } from 'jose';
+import { JWT } from './jwt';
+
+export const KEY_ALG = 'EdDSA'
+
+export interface KeyStateSerialized {
+	private: JWK;
+	public: JWK;
+	publicPEM: string;
+	uuid: string;
+	expiry: number;
+	expired: boolean;
+}
+export class KeyState {
+	private expired: boolean = false;
+	publicKey: KeyLike;
+	publicKeyPEM: string;
+	private privateKey: KeyLike;
+	uuid;
+	lastKey: string | undefined;
+	expiry;
+	constructor() {
+		this.uuid = crypto.randomUUID();
+		this.expiry = 60 * 60 * 24 * 7; // 1 week in millis
+		this.publicKey = {} as KeyLike;
+		this.privateKey = {} as KeyLike;
+		this.publicKeyPEM = '';
+		this.lastKey = undefined;
+	}
+
+	async init() {
+		const { publicKey, privateKey } = await generateKeyPair(KEY_ALG, {
+			extractable: true,
+		});
+		this.publicKey = publicKey;
+		this.privateKey = privateKey;
+		this.publicKeyPEM = await exportSPKI(publicKey);
+	}
+
+	expire() {
+		this.expired = true;
+		this.publicKey = {} as KeyLike;
+		this.privateKey = {} as KeyLike;
+	}
+
+	isExpired(): boolean {
+		return this.expired;
+	}
+
+	async sign(jwt: JWT, expiry: number = 60 * 60 * 24 * 7) {
+		const payload = jwt.payloadRaw(expiry);
+
+		return new SignJWT(payload).setProtectedHeader({ alg: KEY_ALG }).sign(this.privateKey);
+	}
+
+	pub() {
+		return this.publicKeyPEM;
+	}
+
+	async serialize(): Promise<KeyStateSerialized> {
+		return {
+			private: await exportJWK(this.privateKey),
+			public: await exportJWK(this.publicKey),
+			uuid: this.uuid,
+			expiry: this.expiry,
+			expired: this.expired,
+			publicPEM: this.publicKeyPEM,
+		};
+	}
+
+	static async deserialize(keySerialized: KeyStateSerialized) {
+		const key = new KeyState();
+		key.privateKey = (await importJWK<KeyLike>(keySerialized.private, KEY_ALG)) as KeyLike;
+		key.publicKey = (await importJWK<KeyLike>(keySerialized.public, KEY_ALG)) as KeyLike;
+		key.uuid = keySerialized.uuid;
+		key.expiry = keySerialized.expiry;
+		key.expired = keySerialized.expired;
+		key.publicKeyPEM = keySerialized.publicPEM;
+		return key;
+	}
+}

--- a/apps/authx_token_api/vitest.config.ts
+++ b/apps/authx_token_api/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+/*import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
   test: {
@@ -8,4 +8,11 @@ export default defineWorkersConfig({
       },
     },
   },
-});
+});*/
+
+import { defineConfig } from 'vitest/config'
+export default defineConfig({
+  test: {
+    exclude: [],
+  },
+})

--- a/apps/data_channel_gateway/tests/jwt.spec.ts
+++ b/apps/data_channel_gateway/tests/jwt.spec.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { env } from 'cloudflare:test';
-import {importJWK, jwtVerify} from "jose"
+import {importJWK, jwtVerify, createLocalJWKSet} from "jose"
 describe("jwt integration tests", () => {
   it("can get the public key", async () =>{
     console.log(env)
@@ -52,17 +52,17 @@ describe("jwt integration tests", () => {
   it("can use jwks", async () => {
     const jwtDoId = env.JWT_TOKEN_DO.idFromName("default")
     const jwtStub = env.JWT_TOKEN_DO.get(jwtDoId)
-    const jwk = await jwtStub.getPublickKeyJWK()
+    const jwk = await jwtStub.getJWKS()
     console.log(jwk)
     expect(jwk).toBeDefined()
-    const publicKey = await importJWK(jwk)
     const jwtRequest = {
       entity: "testuser",
       claims: ["testclaim"],
     }
     const jwtToken = await jwtStub.signJWT(jwtRequest, 1000000000)
 
-  const { payload, protectedHeader } = await jwtVerify(jwtToken.token, publicKey, {
+    const jwkPub = await createLocalJWKSet(jwk);
+  const { payload, protectedHeader } = await jwtVerify(jwtToken.token, jwkPub, {
     issuer: 'catalyst:system:jwt:latest',
     audience: 'catalyst:system:datachannels',
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       base64url:
         specifier: ^3.0.1
         version: 3.0.1
+      bun:
+        specifier: ^1.1.7
+        version: 1.1.7
       jose:
         specifier: ^5.2.4
         version: 5.2.4
@@ -5645,6 +5648,14 @@ packages:
     dev: true
     optional: true
 
+  /@oven/bun-darwin-aarch64@1.1.7:
+    resolution: {integrity: sha512-6xH96IjcQlnbsGziUELOhewuobKyzcc+/mV1fSQkY8+c5crgca1nnArS8ja7GaduDWCGuSvMiURFUtf/EAZYtg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@oven/bun-darwin-x64-baseline@1.0.30:
     resolution: {integrity: sha512-hx32GA5bMJdOK8WlioiaFjx1vr6ZDBgi4sg50cCJmoK0grg5yNVcOlmRz8g6Q5ngfR8dKC61R7B++hnZtOpTHw==}
     cpu: [x64]
@@ -5663,6 +5674,14 @@ packages:
 
   /@oven/bun-darwin-x64-baseline@1.1.6:
     resolution: {integrity: sha512-amG6o1y1ksjwOUKS97IW5VQE/UPfEa4Edket1+VUa0UGvo/0z3+2gVYF3Bt+pZA45glJKXM3nI9wYlmVeE/AcQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-darwin-x64-baseline@1.1.7:
+    resolution: {integrity: sha512-oMKWmT5lqrnew/cmB+Mmuy/X7X0dBXnyJgsPp1RmV665u7UlNgRGncXhaW/EXlPJk4vaXh6UQQ8bLlg6mnQNgg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -5693,6 +5712,14 @@ packages:
     dev: true
     optional: true
 
+  /@oven/bun-darwin-x64@1.1.7:
+    resolution: {integrity: sha512-VL0yT0rfdxU3NHts5aGjve1ui977BDJ9xb1Obw0LALWL4EzgQbiF8q8nUE6B25LwrQLzydUNTgMY0YYVLR2UkA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@oven/bun-linux-aarch64@1.0.30:
     resolution: {integrity: sha512-32AbJ9Jt2sPNBS27QeWkn4MBYBXY0VqkRnh6M41i70I+IvjUj3vdZMMtushOxYdnlPzn+zv7J+JzyeYydvNJcw==}
     cpu: [arm64]
@@ -5711,6 +5738,14 @@ packages:
 
   /@oven/bun-linux-aarch64@1.1.6:
     resolution: {integrity: sha512-FOlZBeIrk7DlOsktWwahmxJwaKxCG9C+pKPMj8s+u08WhAKtfMBpgHvHsilBKE9W1twta+jB+geW4kU1KZSNZg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-linux-aarch64@1.1.7:
+    resolution: {integrity: sha512-/oVeD+f4S2tfIoKXVALuQv68k9O/91aMRCJ8+TlnVvZgZEpE6xdtbrSa+iP1wbAvBUy9ags0AgQOJg1QJzK/ow==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -5741,6 +5776,14 @@ packages:
     dev: true
     optional: true
 
+  /@oven/bun-linux-x64-baseline@1.1.7:
+    resolution: {integrity: sha512-JklT4tgXi83nDyPLcWEfHxLKQnJdtpHG9sSOxpke6TlBwnj84lXbZ+CWhQL/aL9ye1lCTUjEIEbbZph8IhWlWg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@oven/bun-linux-x64@1.0.30:
     resolution: {integrity: sha512-/8e3xDlaFh1AIpwshnau6+ecrIyLD1U85EqohuSFm8guQ/9aoQ/luxr/V+ujfJHay7taImL3mPXHORL7HYVIoA==}
     cpu: [x64]
@@ -5765,6 +5808,14 @@ packages:
     dev: true
     optional: true
 
+  /@oven/bun-linux-x64@1.1.7:
+    resolution: {integrity: sha512-b+yTqZREacwPXcsg6/ps+qAZ/rlyuRztzptX6oNnc42+xd7BpdvKpdu2p8hbN0IoKBMqlAqFedffxFimIOMWFA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@oven/bun-windows-x64-baseline@1.1.3:
     resolution: {integrity: sha512-LgGYYWA6f5FKp3QeT8PCQ6JpQkz2kLu21i6um4BYyh1U7hZb75LoLzetfhdOJa00hy9Zrt+8Z8QnQ7ffmGevyQ==}
     cpu: [x64]
@@ -5781,6 +5832,14 @@ packages:
     dev: true
     optional: true
 
+  /@oven/bun-windows-x64-baseline@1.1.7:
+    resolution: {integrity: sha512-DkclScCfTR8YsNMATn2WVqbIf8cyD/UhIdFa4/R0Qsf+C1BB9jPquXoogSrAUJJyPMSbkBf2KshlROiFjYrjkw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@oven/bun-windows-x64@1.1.3:
     resolution: {integrity: sha512-IBV+DCOAyaQGhtqQ0gliBprMRBoRGwDBSOQJrQ6Df/0t0R7eyJzl8SyR2C89jZ/vK4VsNMgEv5Mxa6zP7SSQOw==}
     cpu: [x64]
@@ -5791,6 +5850,14 @@ packages:
 
   /@oven/bun-windows-x64@1.1.6:
     resolution: {integrity: sha512-knJePhYbqtYv5RNUrnkMFrK4z3dDIPzom402yjSLkESZhsnO16xtLkULocV2yk0KDXKo2C3BqoZKHATCK6LxqQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-windows-x64@1.1.7:
+    resolution: {integrity: sha512-y8qrlwv09UIYKEm9+X1KzHHtaudWWWn7GGwSqCT6c7XYfR70fbnriyCm2i0qUAUTmgtuhY7dwFtAKf1UkQJ2SQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -8258,6 +8325,23 @@ packages:
       '@oven/bun-linux-x64-baseline': 1.1.6
       '@oven/bun-windows-x64': 1.1.6
       '@oven/bun-windows-x64-baseline': 1.1.6
+    dev: true
+
+  /bun@1.1.7:
+    resolution: {integrity: sha512-4Q/ySjXfSTOsehxektQuo376FfI/QMPSjnsBAwQAZsRFW37Hb8IdctOABDEBQcrYmiwgDGKlgdWTQ8/5H0N2ww==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, win32]
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.1.7
+      '@oven/bun-darwin-x64': 1.1.7
+      '@oven/bun-darwin-x64-baseline': 1.1.7
+      '@oven/bun-linux-aarch64': 1.1.7
+      '@oven/bun-linux-x64': 1.1.7
+      '@oven/bun-linux-x64-baseline': 1.1.7
+      '@oven/bun-windows-x64': 1.1.7
+      '@oven/bun-windows-x64-baseline': 1.1.7
     dev: true
 
   /busboy@1.6.0:


### PR DESCRIPTION
There was an interesting issue where keys reimported from JWK format are no longer exportable.

This now necessitates the use of the serialized key and all key functions now have to recall the key first to ensure the key is loaded (and the serialized/jwks) is loaded from memory as well
