### PR TITLE
fix renaming channels

### DIFF
--- a/apps/catalyst-ui/components/channels/ChannelDetails.tsx
+++ b/apps/catalyst-ui/components/channels/ChannelDetails.tsx
@@ -200,7 +200,8 @@ export default function DataChannelDetailsComponent({
                         formData.append("organization", user?.custom.org);
                         formData.set(
                           "name",
-                          user?.custom.org + "/" + editChannel.name
+
+                          user?.custom.org + "/" + formData.get("name")
                         );
                         updateChannel(formData, token).then(
                           fetchChannelDetails


### PR DESCRIPTION
### TL;DR

A change was made to correct the behavior in ChannelDetails component when updating channel name.

### What changed?

Instead of using the editChannel for org name, we use the formData.get("name"), so the end result is what the user is expecting

