### PR TITLE
filter by status

### DIFF
--- a/apps/catalyst-ui/components/partners/PartnerDetailedComponent.tsx
+++ b/apps/catalyst-ui/components/partners/PartnerDetailedComponent.tsx
@@ -1,30 +1,20 @@
 "use client";
 export const runtime = "edge";
 import {
+  APIKeyText,
   OpenButton,
   OrbisBadge,
-  OrbisButton,
   OrbisCard,
   OrbisTable,
-  TrashButton,
 } from "@/components/elements";
 import { ListView } from "@/components/layouts";
 import { navigationItems } from "@/utils/nav.utils";
 import { DataChannel } from "@catalyst/schema_zod";
-import { Box, Flex, Stack, StackDivider } from "@chakra-ui/layout";
-import {
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Switch,
-  useDisclosure,
-} from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/layout";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useUser } from "../contexts/User/UserContext";
+import { Text } from "@chakra-ui/layout";
 type PartnerDetailedComponentProps = {
   listPartnersChannels: (
     token: string,
@@ -64,12 +54,20 @@ export default function PartnerDetailedComponent({
             <OrbisTable
               headers={["Channel"]}
               rows={channels.map((channel, index) => [
-                <Flex key={index} justifyContent={"space-between"}>
+                <Flex
+                  key={index}
+                  justifyContent={"space-between"}
+                  alignItems={"center"}
+                >
                   <OpenButton
                     onClick={() => router.push(`/channels/${channel.id}`)}
                   >
                     {channel.name}
                   </OpenButton>
+                  <Text>{channel.description}</Text>
+                  <APIKeyText allowCopy showAsClearText>
+                    {channel.id}
+                  </APIKeyText>
                 </Flex>,
               ])}
               tableProps={{}}


### PR DESCRIPTION
### TL;DR
Added filtering functionality to list and display data channels based on ownership and sharing status.

### What changed?
- Added filtering options for displaying all, subscribed, or owned data channels
- sorts channels by name 
- Updated UI to include filter buttons and dynamic table rows
Before: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/gTJhzORipy1tCg65Vgvf/8b0b290f-d7ec-458d-b470-c5382afaa7c9.png)

Now: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/gTJhzORipy1tCg65Vgvf/6a4836df-d96b-4d7f-a432-88854b7f1e1b.png)


### How to test?
1. Check that the filter buttons work as expected
2. Verify that data channels are displayed based on the selected filter

### Why make this change?
Enhances user experience by providing the ability to filter and view data channels based on ownership and sharing status.

---

