### PR TITLE
add Back button to partner detailed view

### DIFF
--- a/apps/catalyst-ui/components/partners/PartnerDetailedComponent.tsx
+++ b/apps/catalyst-ui/components/partners/PartnerDetailedComponent.tsx
@@ -7,7 +7,7 @@ import {
   OrbisCard,
   OrbisTable,
 } from "@/components/elements";
-import { ListView } from "@/components/layouts";
+import { DetailedView } from "@/components/layouts";
 import { navigationItems } from "@/utils/nav.utils";
 import { DataChannel } from "@catalyst/schema_zod";
 import { Flex } from "@chakra-ui/layout";
@@ -38,7 +38,7 @@ export default function PartnerDetailedComponent({
     }
   }, [params.id, token]);
   return (
-    <ListView
+    <DetailedView
       topbaractions={navigationItems}
       showspinner={!token}
       actions={<></>}
@@ -48,34 +48,32 @@ export default function PartnerDetailedComponent({
       }}
       positionChildren="bottom"
       subtitle=""
-      table={
-        <Flex gap={10}>
-          <OrbisCard pb={0} header={"Shared Channels"} flex={2}>
-            <OrbisTable
-              headers={["Channel"]}
-              rows={channels.map((channel, index) => [
-                <Flex
-                  key={index}
-                  justifyContent={"space-between"}
-                  alignItems={"center"}
-                >
-                  <OpenButton
-                    onClick={() => router.push(`/channels/${channel.id}`)}
-                  >
-                    {channel.name}
-                  </OpenButton>
-                  <Text>{channel.description}</Text>
-                  <APIKeyText allowCopy showAsClearText>
-                    {channel.id}
-                  </APIKeyText>
-                </Flex>,
-              ])}
-              tableProps={{}}
-            />
-          </OrbisCard>
-        </Flex>
-      }
       topbartitle="Partners"
-    ></ListView>
+    >
+      <Flex gap={10}>
+        <OrbisCard pb={0} header={"Shared Channels"} flex={2}>
+          <OrbisTable
+            headers={["Channel"]}
+            rows={channels.map((channel, index) => [
+              <Flex
+                key={index}
+                justifyContent={"space-between"}
+                alignItems={"center"}
+              >
+                <OpenButton
+                  onClick={() => router.push(`/channels/${channel.id}`)}
+                >
+                  {channel.name}
+                </OpenButton>
+                <Text>{channel.description}</Text>
+                <APIKeyText allowCopy showAsClearText>
+                  {channel.id}
+                </APIKeyText>
+              </Flex>,
+            ])}
+          />
+        </OrbisCard>
+      </Flex>
+    </DetailedView>
   );
 }


### PR DESCRIPTION
### TL;DR

Refactored the layout in PartnerDetailedComponent from ListView to DetailedView.

### What changed?

Replaced ListView with DetailedView in PartnerDetailedComponent. Removed the table wrapper around the OrbisTable component and directly inserted it into the DetailedView layout.
Before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/gTJhzORipy1tCg65Vgvf/c8db28ee-74ab-4bfd-b72e-4d89753b6c08.png)


Now
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/gTJhzORipy1tCg65Vgvf/e129de74-7fd5-43e8-b973-9e2292c9a8c9.png)


### How to test?

To test, navigate to the partner detail view in the Catalyst UI and verify that the layout appears correctly. The OrbisTable displaying the shared channels should now be directly in the DetailedView layout.

### Why make this change?

This change is made to ensure more clarity and linearity for our components. Using the DetailedView layout aligns better with our design principles and improves user experience.

---

