### PR TITLE
Get Data Custodian Role from Cache Enabled

### DIFF
--- a/apps/authx_authzed_api/src/index.ts
+++ b/apps/authx_authzed_api/src/index.ts
@@ -13,9 +13,8 @@ const emailTob64 = (email: string) => {
 };
 
 export default class AuthzedWorker extends WorkerEntrypoint<Env> {
-
 	async fetch(req: Request) {
-		return Response.json({message: "placeholder"})
+		return Response.json({ message: 'placeholder' });
 	}
 
 	async schema() {
@@ -166,9 +165,17 @@ export default class AuthzedWorker extends WorkerEntrypoint<Env> {
 
 	async canReadFromDataChannel(dataChannelId: DataChannelId, userId: UserId) {
 		const client = new AuthzedClient(this.env.AUTHZED_ENDPOINT, this.env.AUTHZED_KEY, this.env.AUTHZED_PREFIX);
-		const owningResp = await client.dataChannelPermissionsCheck(dataChannelId, emailTob64(userId), Catalyst.DataChannel.PermissionsEnum.enum.read_by_owning_org);
-		const parterResp = await client.dataChannelPermissionsCheck(dataChannelId, emailTob64(userId), Catalyst.DataChannel.PermissionsEnum.enum.read_by_partner_org);
-		console.log(`data channel permission check asserts local(${owningResp}) and partner(${parterResp}) paths`)
+		const owningResp = await client.dataChannelPermissionsCheck(
+			dataChannelId,
+			emailTob64(userId),
+			Catalyst.DataChannel.PermissionsEnum.enum.read_by_owning_org,
+		);
+		const parterResp = await client.dataChannelPermissionsCheck(
+			dataChannelId,
+			emailTob64(userId),
+			Catalyst.DataChannel.PermissionsEnum.enum.read_by_partner_org,
+		);
+		console.log(`data channel permission check asserts local(${owningResp}) and partner(${parterResp}) paths`);
 		return owningResp || parterResp;
 	}
 }

--- a/apps/user_credentials_cache/src/index.ts
+++ b/apps/user_credentials_cache/src/index.ts
@@ -41,7 +41,7 @@ type OrganizationWithRoles = {
 };
 
 function getOrgFromRoles(roles: Roles): OrganizationWithRoles | undefined {
-	const adminRoles = ['platform-admin', 'org-admin', 'org-user'];
+	const adminRoles = ['platform-admin', 'org-admin', 'org-user', 'data-custodian'];
 	const roleKeys = Object.keys(roles);
 	let rolesList = roleKeys.filter((key) => adminRoles.includes(key));
 	const adminRoleKey = roleKeys.find((key) => adminRoles.includes(key));

--- a/packages/schema_zod/types.ts
+++ b/packages/schema_zod/types.ts
@@ -30,7 +30,9 @@ export type Token = z.infer<typeof Token>;
 export const User = z.object({
   userId: UserId,
   orgId: OrgId,
-  zitadelRoles: z.enum(["platform-admin", "org-admin", "org-user"]).array(),
+  zitadelRoles: z
+    .enum(["platform-admin", "org-admin", "org-user", "data-custodian"])
+    .array(),
 });
 
 export type User = z.infer<typeof User>;


### PR DESCRIPTION
### TL;DR

This PR introduces improvements to permission checks and adds a new role to user roles.

### What changed?

Within user roles, we've added the 'data-custodian' role to our array of administrative roles. This ensures a user with this role is correctly identified as having administrative permissions.

