### PR TITLE
add readme to org matchmaking

### DIFF
--- a/apps/organization_matchmaking/README.md
+++ b/apps/organization_matchmaking/README.md
@@ -1,0 +1,47 @@
+# Organization Matchmaking
+
+A Cloudflare Workers-based service for managing partnerships between organizations in the Catalyst platform. This service provides invitation management, partnership tracking, and permission-based controls for organization-to-organization relationships.
+
+## Purpose
+
+The Organization Matchmaking service facilitates collaboration between organizations in the Catalyst ecosystem by offering:
+
+- Partnership invitation system with request/accept/decline workflow
+- Organization-to-organization connection management
+- Persistent tracking of partnership status
+- Ability to enable or disable existing partnerships
+
+## Architecture
+
+This service is built using:
+
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/) - Serverless execution environment
+- [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/) - For persistent storage of invitations and partnerships
+- TypeScript - For type-safe implementation
+
+The application is structured around two main components:
+
+1. `OrganizationMatchmakingWorker` - The entry point class that handles requests and permission verification
+2. `OrganizationMatchmakingDO` - A Durable Object that provides persistent storage and invitation management
+
+## Features
+
+### Invitation Management
+
+- **Send Invites**: Create partnership invitations between organizations
+- **Accept Invites**: Approve incoming partnership requests
+- **Decline Invites**: Reject partnership requests
+- **List Invites**: View all incoming and outgoing invitations
+- **Read Invites**: View details of specific invitations
+
+### Partnership Management
+
+- **Toggle Partnerships**: Enable or disable existing partnerships without removing them
+- **Partnership Status**: Track the state of partnerships (pending, accepted, declined)
+- **Custom Messages**: Include optional messages with partnership invitations
+
+### Security
+
+- **Permission-based Control**: Only authorized users can manage partnerships
+- **Organization Isolation**: Organizations can only manage their own invitations
+


### PR DESCRIPTION
# Organization Matchmaking Service

### TL;DR

Added a new Organization Matchmaking service for managing partnerships between organizations in the Catalyst platform.

### What changed?

Created a README.md file for the Organization Matchmaking service that outlines:
- The purpose of the service for facilitating organization-to-organization collaborations
- The architecture using Cloudflare Workers and Durable Objects
- Core features including invitation management (send, accept, decline, list, read)
- Partnership management capabilities (toggle, status tracking, custom messages)
- Security controls with permission-based access

### How to test?

Review the README.md documentation to understand the service's capabilities and architecture. The actual implementation can be tested once the service is deployed by:
1. Creating partnership invitations between organizations
2. Accepting/declining invitations
3. Verifying partnership status tracking
4. Testing permission controls for unauthorized users

### Why make this change?

This service enables collaboration between organizations in the Catalyst ecosystem by providing a structured way to establish and manage partnerships. It addresses the need for a formal invitation workflow, persistent tracking of relationships, and proper permission controls for cross-organizational interactions.