### PR TITLE
add readme to data channel registrar

### DIFF
--- a/apps/data_channel_registrar/README.md
+++ b/apps/data_channel_registrar/README.md
@@ -1,0 +1,57 @@
+# Data Channel Registrar
+
+A Cloudflare Workers-based service for managing the registration and lifecycle of data channels within the Catalyst project. This service provides a central registry for tracking data channels and managing access permissions.
+
+## Purpose
+
+The Data Channel Registrar serves as the central repository for data channel management in the Catalyst ecosystem, offering:
+
+- Registration and discovery of data channels
+- Permission-based access control for data channels
+- Organization-based data channel ownership
+- Integration with authentication and authorization services
+- Ability to enable/disable data channel access
+
+## Architecture
+
+This service is built using:
+
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/) - Serverless execution environment
+- [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/) - For persistent storage of data channel registrations
+- TypeScript - For type-safe implementation
+
+The application is structured around two main components:
+
+1. `RegistrarWorker` - The entry point class that handles requests and permissions
+2. `Registrar` - A Durable Object that provides persistent storage and data management
+
+## Features
+
+### Data Channel Management
+
+- **Create**: Register new data channels with metadata
+- **Read**: Retrieve data channel details
+- **Update**: Modify data channel properties
+- **Delete**: Remove data channels
+- **List**: Discover available data channels based on permissions
+
+### Permission Management
+
+- **CUD Permissions**: Create, Update, Delete permissions for data channels
+- **Read Permissions**: Access control for reading data channel information
+- **Organization Isolation**: Data channels are owned by organizations
+- **JWT-based Access**: Support for JWT token-based access to data channels. Provides access to external organizations who do not own the data channel. This access can only be coordinated via invitation from the owning organization to the invited external organization
+
+# Integration 
+
+This service is a critical component in the Catalyst ecosystem:
+
+- Used by the Data Channel Gateway to discover available data channels
+- Integrates with AuthX services for authentication and authorization
+- Enforces organization boundaries and access controls
+- Provides consistent data channel information across the platform
+
+### Data Isolation
+- Data channels are owned by specific organizations
+- Users can only access data channels they have permission for
+- JWT tokens must explicitly include data channel claims


### PR DESCRIPTION
### TL;DR

Added a README for the Data Channel Registrar service, documenting its purpose, architecture, and features.

### What changed?

Created a new README.md file for the Data Channel Registrar application that:
- Explains the service's purpose as a central registry for tracking data channels and managing access permissions
- Details the architecture using Cloudflare Workers, Durable Objects, and TypeScript
- Documents key features including data channel management operations (CRUD)
- Describes permission management capabilities including organization isolation and JWT-based access
- Outlines how the service integrates with the broader Catalyst ecosystem

### How to test?

Review the README.md file in the apps/data_channel_registrar directory to ensure it accurately describes the service's functionality and provides sufficient documentation for developers working with the Data Channel Registrar.

### Why make this change?

This documentation helps developers understand the purpose and functionality of the Data Channel Registrar service within the Catalyst project. It provides essential information about the service's architecture, features, and integration points, making it easier for team members to work with and maintain the service.