### PR TITLE
init README data channel gateway

### DIFF
--- a/apps/data_channel_gateway/README.md
+++ b/apps/data_channel_gateway/README.md
@@ -1,8 +1,58 @@
-```
-npm install
-npm run dev
-```
+# Data Channel Gateway
+
+A GraphQL gateway service for the Catalyst project that dynamically federates and stitches together GraphQL schemas from various data channels. This service provides a unified API entry point with authentication, authorization, and schema stitching capabilities.
+
+## Purpose
+
+The Data Channel Gateway serves as the centralized access point for GraphQL APIs within the Catalyst ecosystem, offering:
+
+- A unified GraphQL endpoint for all data channels
+- JWT-based authentication and authorization
+- Dynamic schema stitching and federation
+- Token validation and revocation checking
+- Secure routing to registered data channels
+
+## Architecture
+
+This service is built using:
+
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/) - Serverless execution environment
+- [Hono](https://hono.dev/) - Lightweight web framework
+- [GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) - GraphQL server
+- [GraphQL Tools](https://the-guild.dev/graphql/tools) - For schema stitching and federation
+- TypeScript - For type-safe implementation
+
+## Features
+
+
+### GraphQL Federation
+
+- **Dynamic Schema Stitching**: Combines multiple GraphQL schemas into a single unified API
+- **Remote Schema Fetching**: Retrieves schemas from registered data channels
+
+
+## Integration
+
+The Data Channel Gateway integrates with the following services:
+
+- [Data Channel Registrar](../data_channel_registrar/README.md) - Provides data channel registration and discovery
+- [AuthX]() - Provides authentication and authorization services
+- [User Credentials Cache](../user_credentials_cache/README.md) - Provides user credentials cache services
+- [AuthX AuthZed API]() - Provides authorization services
+- [AuthX Token API]() - Provides token validation services
+
+## Development
 
 ```
-npm run deploy
+pnpm install
+pnpm run dev
 ```
+
+
+## Deployment
+
+```
+pnpm run deploy
+```
+
+


### PR DESCRIPTION
### TL;DR

Enhanced the Data Channel Gateway README with comprehensive documentation about the service's purpose, architecture, and features.

### What changed?

Expanded the README.md file for the Data Channel Gateway service with:
- Added a clear service description and purpose statement
- Documented the architecture and technology stack (Cloudflare Workers, Hono, GraphQL Yoga, etc.)
- Outlined key features including GraphQL federation and dynamic schema stitching
- Added integration details with other services like Data Channel Registrar, AuthX, and User Credentials Cache
- Updated the development and deployment commands to use pnpm instead of npm

### How to test?

Review the README.md file to ensure it provides clear and comprehensive information about the Data Channel Gateway service.

### Why make this change?

This documentation improvement helps developers better understand the Data Channel Gateway's role in the Catalyst ecosystem, its technical implementation, and how it integrates with other services. The enhanced README provides essential context for anyone working with or maintaining this service.