### PR TITLE
fix(authx_authzed_api): replace deprecated node_compat with nodejs_compat for Wrangler v4

### DIFF
--- a/apps/authx_authzed_api/wrangler.toml
+++ b/apps/authx_authzed_api/wrangler.toml
@@ -1,7 +1,7 @@
 name = "authx_authzed_api"
 main = "src/index.ts"
 compatibility_date = "2024-04-05"
-node_compat = true
+compatibility_flags = ["nodejs_compat"]
 # will preserve vars in the remote deployment
 keep_vars = true
 


### PR DESCRIPTION
before change:
```
ihammerstrom@Ians-MacBook-Pro apps % cd authx_authzed_api && pnpm wrangler dev --port 5054

 ⛅️ wrangler 4.9.1
------------------


✘ [ERROR] Processing wrangler.toml configuration:

    - Removed: "node_compat":
      The "node_compat" field is no longer supported
  as of Wrangler v4. Instead, use the `nodejs_compat`
  compatibility flag. This includes the functionality
  from legacy `node_compat` polyfills and natively
  implemented Node.js APIs. See
  https://developers.cloudflare.com/workers/runtime-apis/nodejs
  for more information.
```
after change:
```
  hammerstrom@Ians-MacBook-Pro authx_authzed_api % pnpm wrangler dev --port 5054

 ⛅️ wrangler 4.9.1
------------------

No bindings found.
⎔ Starting local server...
[wrangler:inf] Ready on http://localhost:5054
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│  [b] open a browser, [d] open devtools, [l] turn off local mode, [c] clear console, [x] to exit  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```