### PR TITLE
chore updated node and pnpm versions in workflow automation

### DIFF
--- a/.github/workflows/dependency_management.yaml
+++ b/.github/workflows/dependency_management.yaml
@@ -15,16 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '22'
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         with:
-          version: 8
+          version: 10
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/deployment_to_demo.yaml
+++ b/.github/workflows/deployment_to_demo.yaml
@@ -20,16 +20,15 @@ jobs:
         with:
           ref: 'demo'
 
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/deployment_to_staging.yaml
+++ b/.github/workflows/deployment_to_staging.yaml
@@ -6,7 +6,7 @@ name: 'Preview Deployment'
 #     branches:
 #       - staging
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 # Limit to 1 concurrent run per workflow run
 concurrency:
@@ -23,16 +23,15 @@ jobs:
         with:
           ref: 'staging'
 
-
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
### TL;DR

Upgraded Node.js from v18 to v22 and pnpm from v8 to v10 across all GitHub workflow files.

### What changed?

- Updated Node.js version from 18 to 22 in all workflow files:
  - `dependency_management.yaml`
  - `deployment_to_demo.yaml`
  - `deployment_to_staging.yaml`
- Upgraded pnpm version from 8 to 10 in the same workflow files
- Fixed minor formatting issues in the workflow files

### How to test?

1. Verify that the GitHub workflows run successfully with the new Node.js and pnpm versions
2. Confirm that all build and deployment steps function as expected with the updated toolchain

### Why make this change?

Keeping our development toolchain up-to-date with the latest stable versions of Node.js and pnpm ensures we benefit from:
- Performance improvements in Node.js 22
- New features and bug fixes in both Node.js and pnpm
- Better long-term support and security updates
- Compatibility with modern dependencies and development practices