### PR TITLE
Export getOrgFromRoles function and add comprehensive tests

### DIFF
--- a/apps/user_credentials_cache/src/index.ts
+++ b/apps/user_credentials_cache/src/index.ts
@@ -22,7 +22,7 @@ type OrganizationWithRoles = {
 	roles: string[];
 };
 
-function getOrgFromRoles(roles: Roles): OrganizationWithRoles | undefined {
+export function getOrgFromRoles(roles: Roles): OrganizationWithRoles | undefined {
 	const adminRoles = ['platform-admin', 'org-admin', 'org-user', 'data-custodian'];
 	const roleKeys = Object.keys(roles);
 	let rolesList = roleKeys.filter((key) => adminRoles.includes(key));

--- a/apps/user_credentials_cache/test/index.spec.ts
+++ b/apps/user_credentials_cache/test/index.spec.ts
@@ -1,10 +1,54 @@
 import { env, runInDurableObject } from 'cloudflare:test';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 import { User } from '../../../packages/schema_zod/types';
-import { UserCredsCache } from '../src';
+
+import { UserCredsCache, getOrgFromRoles } from '../src';
+ 
+ 
+// Mock data for testing
+const mockUser: User = {
+	userId: 'test-user-id',
+	orgId: 'test-org-id',
+	zitadelRoles: ['platform-admin', 'org-admin', 'org-user', 'data-custodian'],
+};
+
+// Mock response for Cloudflare Access
+const mockCfAccessResponse = {
+	email: 'test-user-id',
+	custom: {
+		'urn:zitadel:iam:org:project:roles': {
+			'platform-admin': { 'test-org-id': 'test-org-id.domain' },
+			'org-admin': { 'test-org-id': 'test-org-id.domain' },
+			'org-user': { 'test-org-id': 'test-org-id.domain' },
+			'data-custodian': { 'test-org-id': 'test-org-id.domain' },
+		},
+	},
+};
+
 
 
 describe('UserCredsCacheWorker', () => {
+
+  describe('getOrgFromRoles', () => {
+		it('should extract org and roles from valid roles object', () => {
+			const roles = mockCfAccessResponse.custom['urn:zitadel:iam:org:project:roles'];
+			const result = getOrgFromRoles(roles);
+			expect(result).toEqual({
+				org: 'test-org-id',
+				roles: ['platform-admin', 'org-admin', 'org-user', 'data-custodian'],
+			});
+		});
+
+		it('should return undefined for invalid roles object', () => {
+			const invalidRoles = {
+				'invalid-role': { 'test-org-id': 'test-org-id.domain' },
+			};
+			const result = getOrgFromRoles(invalidRoles);
+			expect(result).toBeUndefined();
+		});
+	});
+
+
 	describe('getUser', () => {
     afterAll(async () => {
       // delete the cache
@@ -18,15 +62,25 @@ describe('UserCredsCacheWorker', () => {
       });
     });
 
-    it('should fail to get user from cache', async () => {
+    it('should return user from cache when exists', async () => {
       // get the cache RPC stub
 			const id = env.CACHE.idFromName('default');
 			const stub = env.CACHE.get(id);
 
-			const user = await stub.getUser('test-token');
+      // run the test in the durable object
+      // save a dummy user in the cache
+      await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
+        expect(instance).toBeInstanceOf(UserCredsCache);
+        await state.storage.put('cached-token', mockUser);
+        // Mock validateUser to ensure it's not called
+				instance.validateUser = vi.fn().mockRejectedValue(new Error('Should not be called'));
+
+      });
+
+			const user = await stub.getUser('cached-token');
 
       // use had not been created
-      expect(user).toBeUndefined();
+      expect(user).toEqual(mockUser);
 		});
 
 		it('should get user from cache', async () => {
@@ -55,4 +109,74 @@ describe('UserCredsCacheWorker', () => {
       expect(user).toEqual(testData);
 		});
 	});
+  it('should validate and cache user on cache miss', async () => {
+    const id = env.CACHE.idFromName('default');
+    const stub = env.CACHE.get(id);
+    const validateUserSpy = vi.fn().mockResolvedValue(mockUser);
+
+
+  await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
+      expect(instance).toBeInstanceOf(UserCredsCache);
+      instance.validateUser = validateUserSpy;
+    });
+
+    const user = await stub.getUser('new-token');
+    expect(user).toEqual(mockUser);
+    expect(validateUserSpy).toHaveBeenCalledWith('new-token');
+
+    // Verify user was cached
+    await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
+      const cachedUser = await state.storage.get('new-token');
+      expect(cachedUser).toEqual(mockUser);
+    });
+  });
+
+  it('should return undefined when validation fails', async () => {
+    const id = env.CACHE.idFromName('default');
+    const stub = env.CACHE.get(id);
+    const validateUserSpy = vi.fn().mockResolvedValue(undefined);
+
+    await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
+      expect(instance).toBeInstanceOf(UserCredsCache);
+      instance.validateUser = validateUserSpy;
+    });
+
+    const user = await stub.getUser('invalid-token');
+    expect(user).toBeUndefined();
+    expect(validateUserSpy).toHaveBeenCalledWith('invalid-token');
+  });
+
+describe('purge', () => {
+  it('should remove old tokens for same user', async () => {
+    const id = env.CACHE.idFromName('default');
+    const stub = env.CACHE.get(id);
+    
+    await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
+      // Setup multiple tokens for same user
+      await state.storage.put('old-token-1', mockUser);
+      await state.storage.put('old-token-2', mockUser);
+      await state.storage.put('current-token', mockUser);
+      
+      // Different user's token should not be purged
+      const differentUser = { ...mockUser, userId: 'different-user' };
+      await state.storage.put('different-user-token', differentUser);
+
+      // Trigger purge
+      await instance.purge('current-token', mockUser);
+
+      // Verify old tokens are removed
+      const oldToken1 = await state.storage.get('old-token-1');
+      const oldToken2 = await state.storage.get('old-token-2');
+      expect(oldToken1).toBeUndefined();
+      expect(oldToken2).toBeUndefined();
+
+      // Verify current token and different user's token remain
+      const currentToken = await state.storage.get('current-token');
+      const differentToken = await state.storage.get('different-user-token');
+      expect(currentToken).toEqual(mockUser);
+      expect(differentToken).toEqual(differentUser);
+    });
+  });   
+});         
+
 });


### PR DESCRIPTION
### TL;DR

Export the `getOrgFromRoles` function and add comprehensive test coverage for the user credentials cache.

### What changed?

- Made `getOrgFromRoles` function exportable by adding the `export` keyword
- Added extensive test coverage for the `UserCredsCache` module:
  - Tests for `getOrgFromRoles` function to verify it correctly extracts organization and roles
  - Tests for retrieving users from cache when they exist
  - Tests for validating and caching users on cache miss
  - Tests for handling validation failures
  - Tests for the `purge` function to ensure it properly removes old tokens for the same user

### How to test?

1. Run the test suite for the user credentials cache:
   ```
   npm test -- apps/user_credentials_cache
   ```
2. Verify all tests pass, including the new tests for `getOrgFromRoles`, cache retrieval, validation, and purging

### Why make this change?

This change improves test coverage for the user credentials cache, ensuring the reliability of authentication and authorization flows. By exporting the `getOrgFromRoles` function, we can properly test its functionality in isolation. The additional tests verify critical behaviors like token caching, user validation, and token purging, which are essential for maintaining security and performance in the authentication system.