### PR TITLE
chore(docs & testing): updated documentation for authzed development and testing for data channel registrar

### DIFF
--- a/apps/authx_authzed_api/README.md
+++ b/apps/authx_authzed_api/README.md
@@ -40,7 +40,7 @@ Used by the following services:
 
 ### Configuration Changes
 
-- The configuration file has been migrated from `wrangler.toml` to `wrangler.jsonc` (JSON with comments). This new format allows for better structure and comment support. See `wrangler.jsonc` for all environment and deployment settings.
+- The configuration for workers environment is `wrangler.jsonc` (JSON with comments). This new format allows for better structure and comment support. See `wrangler.jsonc` for all environment and deployment settings.
 
 ### Local Development Setup
 
@@ -56,11 +56,20 @@ Used by the following services:
    - Make sure to update these values as needed for your local or remote AuthZed instance.
 
 2. **Running AuthZed Locally with Podman**
+
    - You can run a local AuthZed instance using Podman (or Docker). Example command:
 
      ```sh
-     podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro -p 8443:8443 --detach --name authzed-container authzed/spicedb:latest serve-testing --http-enabled --skip-release-check=true --log-level debug --load-configs ./schema.zaml
+     podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro -p 8443:8443 --detach --name authzed-container authzed/spicedb:latest serve-testing --http-enabled --skip-release-check=true --log-level trace --load-configs ./schema.zaml
      ```
+
+      > [!IMPORTANT]
+      > If want to use CLI tool [authzed/zed](https://github.com/authzed/zed), you need to expose also the port `50051` for `gRPC`.
+      >
+      > Add: `-p 50051:50051` to `podman` flags
+      ---
+      > [!NOTE]
+      > By default the `authx_authzed_api` **CloudFlare Worker™** relies on the HTTP endpoint for connections with SpiceDB. The exposed `gRPC` port is necessary if local development with `authzed/zed` cli tool will be made.
 
    - This will start AuthZed on `localhost:8443` with an in-memory datastore and a pre-shared key matching the `.dev.vars` example above.
    - **Note:** For unit testing, starting AuthZed SpiceDB with Podman is already handled automatically by `global-setup.ts`. You only need to start it manually for local development outside of the test environment.
@@ -76,12 +85,20 @@ Used by the following services:
 
 See the `wrangler.jsonc` file for more configuration options and environment-specific settings.
 
-### Developing with SpiceDB
+### Developing with ZED CLI for SpiceDB
 
-SpiceDB is the open-source authorization database that powers AuthZed. Here's how to work with it effectively:
+`SpiceDB` is the open-source authorization database that powers `AuthZed`. Here's how to work with it effectively:
+
+`authzed/zed` is the CLI tool for connecting via gRPC to a `SpiceDB`.
+> [!NOTE]
+> Install here [authzed/zed](https://github.com/authzed/zed)
+---
+> [!IMPORTANT]
+> When testing locally with `serve-testing` the `SpiceDB` constainer will be in dev/insecure mode.
+> To be able to execute operations against it with zed, every command must contain the `zed --insecure [...]` flag
 
 1. **Schema Development**
-   - The schema is defined in `schema.zaml` in this directory
+   - The schema and default relationships (along with some valistions) are defined in `schema.zaml` in this directory
    - Use the [SpiceDB Playground](https://play.authzed.com/) to test and validate your schema changes
    - Key concepts to understand:
      - **Definitions**: Define your resource types and their relations
@@ -89,17 +106,33 @@ SpiceDB is the open-source authorization database that powers AuthZed. Here's ho
      - **Permissions**: Define computed permissions based on relations
 
 2. **Schema Validation**
-   - After making changes to `schema.zaml`, validate it using the SpiceDB CLI:
+   - After making changes to `schema.zaml`, validate it using the `zed` CLI:
+
      ```sh
-     podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro authzed/spicedb:latest validate /schema.zaml
+     zed validate schema.zaml
      ```
 
 3. **Testing Relationships**
-   - Use the SpiceDB CLI to test relationships:
+   - Use the `zed` CLI to test relationships:
+
+      Instroscpect the schema on `SpiceDB`:
+
      ```sh
-     podman run --rm authzed/spicedb:latest relationship read --endpoint localhost:8443 --token atoken
+     # when running `serve-testing` to need to send token
+     zed schema read --insecure
      ```
-   - Or use the [AuthZed API Explorer](https://app.authzed.com/) for a visual interface
+
+     Create new relationship:
+
+     ```sh
+     zed relationship create orbisops_catalyst_dev/organization:localorg data_custodian orbisops_catalyst_dev/user:myNewUser
+     ```
+
+      Query created relationship:
+
+     ```sh
+     zed relationship read orbisops_catalyst_dev/organization
+     ```
 
 4. **Common Development Patterns**
    - When adding new resources:
@@ -114,12 +147,16 @@ SpiceDB is the open-source authorization database that powers AuthZed. Here's ho
      4. Add migration tests
 
 5. **Debugging Tips**
-   - Enable debug logging in SpiceDB with `--log-level debug`
+   - Enable debug logging in SpiceDB with `--log-level trace`. Trace will print each request.
    - Use the SpiceDB CLI to inspect relationships:
+
+      For making aure a proper schema is loaded
+
      ```sh
-     podman run --rm authzed/spicedb:latest relationship read --endpoint localhost:8443 --token atoken
+     zed schema read
      ```
-   - Check the SpiceDB logs for detailed information about permission checks
+
+   - Check the `SpiceDB` logs for detailed information about permission checks
 
 ## Testing
 

--- a/apps/authx_authzed_api/src/authzed.ts
+++ b/apps/authx_authzed_api/src/authzed.ts
@@ -299,7 +299,6 @@ export class AuthzedClient {
 	}*/
 
 	async organizationPermissionsCheck(orgId: OrgId, userId: UserId, permission: Catalyst.Org.PermissionsEnum) {
-		//zed permission check orbisops_catalyst_dev/organization:Org1  member orbisops_catalyst_dev/user:TestUser --insecure --token atoken
 		const req = this.utils.checkOrgPermission(orgId, userId, permission);
 		const { data } = await this.utils.permissionFetcher(req);
 
@@ -360,7 +359,6 @@ export class AuthzedClient {
 	}
 
 	async dataChannelPermissionsCheck(dataChannelId: DataChannelId, userId: UserId, permission: Catalyst.DataChannel.PermissionsEnum) {
-		//zed permission check orbisops_catalyst_dev/organization:Org1  member orbisops_catalyst_dev/user:TestUser --insecure --token atoken
 		const req = this.utils.checkDataChannelPermission(dataChannelId, userId, permission);
 		const { data } = await this.utils.permissionFetcher(req);
 

--- a/apps/data_channel_gateway/tests/authzed.spec.ts
+++ b/apps/data_channel_gateway/tests/authzed.spec.ts
@@ -7,28 +7,7 @@ describe.sequential("authzed integration tests", () => {
   it.sequential("get schema",  async () => {
     console.log(env)
     const schema = await env.AUTHX_AUTHZED_API.schema()
-    expect(schema).toBeDefined()
-    /*(schema.schemaText).toEqual(`definition orbisops_catalyst_dev/data_channel {
-      \trelation organization: orbisops_catalyst_dev/organization
-      \tpermission read = organization->data_channel_read
-      }
-
-      definition orbisops_catalyst_dev/organization {
-      \trelation admin: orbisops_catalyst_dev/user
-      \trelation data_custodian: orbisops_catalyst_dev/user
-      \trelation user: orbisops_catalyst_dev/user
-      \trelation partner_organization: orbisops_catalyst_dev/organization
-      \trelation data_channel: orbisops_catalyst_dev/data_channel
-      \tpermission member = admin + data_custodian + user
-      \tpermission role_assign = admin
-      \tpermission data_channel_create = data_custodian
-      \tpermission data_channel_update = data_channel_create
-      \tpermission data_channel_delete = data_channel_create
-      \tpermission data_channel_read = admin + data_custodian + user + partner_organization->data_channel_read
-      }
-
-      // Exported from permissions system catalyst dev (orbisops_catalyst_dev) on Fri Apr 05 2024 10:16:05 GMT-0700 (Pacific Daylight Time)
-      definition orbisops_catalyst_dev/user {}`)*/
+    expect(schema).toBeDefined();
   })
 
   describe.sequential("organization tests", () => {

--- a/apps/data_channel_gateway/tests/schema-resilience.spec.ts
+++ b/apps/data_channel_gateway/tests/schema-resilience.spec.ts
@@ -60,7 +60,7 @@ const createMockGraphqlEndpoint = (
                         acc[key] = dataStore[key];
                     }
                     return acc;
-                }, {}),
+                }, {} as Record<string, any>),
             };
         })
         .persist();

--- a/apps/data_channel_registrar/README.md
+++ b/apps/data_channel_registrar/README.md
@@ -70,3 +70,59 @@ pnpm test
 ```
 
 For more details on the test environment setup, see [`global-setup.ts`](./global-setup.ts).
+
+### Testing with Mocked Services
+
+The test environment includes mocked services for:
+
+1. **Cloudflare Access** - Authentication is simulated with predefined tokens and user profiles
+2. **AuthZed** - Authorization service for permission checks
+
+#### User Credentials for Testing
+
+Tests utilize predefined user credentials with specific roles:
+
+```typescript
+// Example user token configuration from vitest.config.ts
+// data format returned by cloudflare access
+const validUsers = {
+  'admin-cf-token': {
+    id: btoa('test-user@email.com'),
+    email: 'test-user@email.com',
+    custom: {
+      'urn:zitadel:iam:org:project:roles': {
+        'data-custodian': {
+          '1234567890098765432': 'localdevorg.provider.io',
+        },
+        // other roles...
+      }
+    }
+  }
+}
+```
+
+When writing integration tests, use these predefined credentials to authenticate requests:
+
+```typescript
+// Example from integration.spec.ts
+const user = {
+  org: 'localdevorg',
+  email: 'test-user@email.com',
+  token: 'admin-cf-token',
+};
+
+// Create a test data channel with auth token
+const createResponse = await SELF.create('default1', dataChannel, {
+  cfToken: user.token,
+});
+```
+
+#### Local Development Environment
+
+The testing configuration (`vitest.config.ts`) sets up a complete local development environment with:
+
+- Mocked Cloudflare Workers and Durable Objects
+- Simulated AuthX services (authx_authzed_api, authx_token_api)
+- User credentials cache with mocked Cloudflare Access responses
+
+This allows for comprehensive testing without external dependencies.

--- a/apps/data_channel_registrar/src/worker.ts
+++ b/apps/data_channel_registrar/src/worker.ts
@@ -144,7 +144,6 @@ export default class RegistrarWorker extends WorkerEntrypoint<Env> {
 
   async create(doNamespace: string, dataChannel: Omit<DataChannel, 'id'>, token: Token) {
     const checkResp = await this.CUDPerms(token);
-    console.error('checkResp', checkResp);
     if (!checkResp.success) {
       return DataChannelActionResponse.parse({
         success: false,

--- a/apps/user-credentials-cache/src/index.ts
+++ b/apps/user-credentials-cache/src/index.ts
@@ -74,7 +74,6 @@ export class UserCredsCache extends DurableObject<Env> {
 		});
 
 		if (!resp.ok) {
-			console.error('error validating user with cloudflare-access');
 			return undefined;
 		}
 

--- a/apps/user-credentials-cache/test/index.spec.ts
+++ b/apps/user-credentials-cache/test/index.spec.ts
@@ -3,8 +3,8 @@ import { afterAll, describe, expect, it, vi } from 'vitest';
 import { User } from '../../../packages/schema_zod/types';
 
 import { UserCredsCache, getOrgFromRoles } from '../src';
- 
- 
+
+
 // Mock data for testing
 const mockUser: User = {
 	userId: 'test-user-id',
@@ -25,10 +25,7 @@ const mockCfAccessResponse = {
 	},
 };
 
-
-
 describe('UserCredsCacheWorker', () => {
-
   describe('getOrgFromRoles', () => {
 		it('should extract org and roles from valid roles object', () => {
 			const roles = mockCfAccessResponse.custom['urn:zitadel:iam:org:project:roles'];
@@ -150,13 +147,13 @@ describe('purge', () => {
   it('should remove old tokens for same user', async () => {
     const id = env.CACHE.idFromName('default');
     const stub = env.CACHE.get(id);
-    
+
     await runInDurableObject(stub, async (instance: UserCredsCache, state: DurableObjectState) => {
       // Setup multiple tokens for same user
       await state.storage.put('old-token-1', mockUser);
       await state.storage.put('old-token-2', mockUser);
       await state.storage.put('current-token', mockUser);
-      
+
       // Different user's token should not be purged
       const differentUser = { ...mockUser, userId: 'different-user' };
       await state.storage.put('different-user-token', differentUser);
@@ -176,7 +173,7 @@ describe('purge', () => {
       expect(currentToken).toEqual(mockUser);
       expect(differentToken).toEqual(differentUser);
     });
-  });   
-});         
+  });
+});
 
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ catalogs:
       specifier: ^2.8.2
       version: 2.10.7
     '@cloudflare/vitest-pool-workers':
-      specifier: ^0.8.15
+      specifier: ^0.8.22
       version: 0.8.23
     '@cloudflare/workers-types':
       specifier: ^4.20250414.0
@@ -184,10 +184,10 @@ catalogs:
       specifier: ^9.0.1
       version: 9.0.1
     vitest:
-      specifier: 3.0.9
+      specifier: ~3.0.7
       version: 3.0.9
     wrangler:
-      specifier: ^4.13.1
+      specifier: ^4.13.2
       version: 4.13.2
     xml-js:
       specifier: ^1.6.11
@@ -4914,7 +4914,6 @@ packages:
 
   bun@1.2.11:
     resolution: {integrity: sha512-9brVfsp6/TYVsE3lCl1MUxoyKhvljqyL1MNPErgwsOaS9g4Gzi2nY+W5WtRAXGzLrgz5jzsoGHHwyH/rTeRCIg==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -15312,7 +15311,7 @@ snapshots:
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@9.25.1(jiti@2.4.2))
@@ -15332,7 +15331,7 @@ snapshots:
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.25.1(jiti@2.4.2))
@@ -15348,8 +15347,8 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/parser': 6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       eslint-config-xo-space: 0.35.0(eslint@9.25.1(jiti@2.4.2))
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-mocha: 10.5.0(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-n: 15.7.0(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-perfectionist: 2.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
@@ -15399,21 +15398,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@8.1.1)
-      eslint: 9.25.1(jiti@2.4.2)
-      get-tsconfig: 4.10.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.13
-      unrs-resolver: 1.7.2
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -15425,7 +15409,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -15440,18 +15424,33 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0(supports-color@8.1.1)
+      eslint: 9.25.1(jiti@2.4.2)
+      get-tsconfig: 4.10.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.13
+      unrs-resolver: 1.7.2
+    optionalDependencies:
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -15483,7 +15482,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -15494,7 +15493,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15512,7 +15511,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -15541,7 +15540,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   "@chakra-ui/theme-tools": ^2.1.2
   "@cloudflare/next-on-pages": ^1.11.2
   "@cloudflare/workers-types": ^4.20250414.0
-  "@cloudflare/vitest-pool-workers": ^0.8.15
+  "@cloudflare/vitest-pool-workers": ^0.8.22
   "@emotion/react": ^11.11.4
   "@eslint/js": ^9.24.0
   "@flydotio/dockerfile": ^0.5.7
@@ -69,7 +69,7 @@ catalog:
   typescript: ^5.8.3
   unstorage: ^1.10.2
   uuid: ^9.0.1
-  vitest: 3.0.9
-  wrangler: ^4.13.1
+  vitest: ~3.0.7
+  wrangler: ^4.13.2
   xml-js: ^1.6.11
   kill-port: ^2.0.1


### PR DESCRIPTION
### TL;DR

Enhanced testing documentation with detailed guides for permission system integration testing and improved SpiceDB development workflows.

### What changed?

- Added comprehensive documentation for integration testing with the SpiceDB permission system
- Expanded the TESTING.md guide with examples for setting up permission relationships and testing resource access
- Enhanced the authx_authzed_api README with detailed instructions for using the ZED CLI tool
- Improved documentation for local development with SpiceDB, including container setup and CLI usage
- Added examples for testing with preconfigured users and permission relationships
- Fixed and improved integration tests in data_channel_registrar
- Updated the vitest configuration with proper user mocking for Cloudflare Access

### How to test?

1. Review the updated TESTING.md for new integration testing patterns
2. Try the SpiceDB local development setup using the provided podman command:
   ```sh
   podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro -p 8443:8443 -p 50051:50051 --detach --name authzed-container authzed/spicedb:latest serve-testing --http-enabled --skip-release-check=true --log-level trace --load-configs ./schema.zaml
   ```
3. Test the ZED CLI commands for schema validation and relationship management:
   ```sh
   zed validate schema.zaml
   zed schema read --insecure
   zed relationship create orbisops_catalyst_dev/organization:localorg data_custodian orbisops_catalyst_dev/user:myNewUser
   ```
4. Run the integration tests in data_channel_registrar to verify permission checks