### PR TITLE
Bugfix for org permissions checking issue

### DIFF
--- a/apps/authx_authzed_api/src/authzed.ts
+++ b/apps/authx_authzed_api/src/authzed.ts
@@ -304,8 +304,8 @@ export class AuthzedClient {
 
 		const permissionResp = Authzed.Permissions.Response.parse(data);
 		if (typeof permissionResp === typeof Authzed.Permissions.CheckReponse) {
-			const success = Authzed.Permissions.CheckReponse.parse(permissionResp);
-			return success.permissionship === Authzed.Permissions.PermissionValues.enum.PERMISSIONSHIP_HAS_PERMISSION;
+			const response = Authzed.Permissions.CheckReponse.safeParse(permissionResp);
+			return response.success && response.data.permissionship === Authzed.Permissions.PermissionValues.enum.PERMISSIONSHIP_HAS_PERMISSION;
 		}
 		return false;
 	}


### PR DESCRIPTION
### TL;DR

Fixed permission checking in the AuthzedClient class to properly handle response parsing and validation.

### What happened?
- The `uthzed.Permissions.CheckReponse.parse` did a hard `throw error` when the reponse was not in the expected shape.

### What changed?

- Modified the permission check method to use `safeParse` instead of `parse` to handle potential parsing errors
- Added a success check on the response before accessing the permissionship property

### How to test?

1. Test permission checks with valid and invalid responses to ensure proper handling
2. Verify that permission checks correctly return false when parsing fails
3. Confirm that the permission check still returns the correct boolean value based on the permissionship value

### Why make this change?

The previous implementation could throw errors when parsing invalid responses. Using `safeParse` provides better error handling by returning a result object with a success flag, preventing potential runtime errors and making the code more robust.