### PR TITLE
chore(test): project wide testing implemented for supported apps

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 pnpm lint-staged
 
 # TODO: Uncomment this once we get the tests working
-# pnpm test
-
+pnpm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,8 @@
 {
     "trailingComma": "es5",
     "tabWidth": 4,
-    "semi": false,
-    "singleQuote": true
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 120,
+    "proseWrap": "preserve"
 }

--- a/apps/authx_authzed_api/package.json
+++ b/apps/authx_authzed_api/package.json
@@ -7,6 +7,7 @@
 		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
 		"dev": "wrangler dev --port 5050",
 		"test": "vitest",
+		"test:workspace": "vitest run --silent",
 		"build": "wrangler build"
 	},
 	"devDependencies": {

--- a/apps/authx_token_api/global-setup.ts
+++ b/apps/authx_token_api/global-setup.ts
@@ -3,50 +3,53 @@ import path from 'node:path';
 
 // Global setup runs inside Node.js, not `workerd`
 export default function () {
-  // Build `api-service`'s dependencies
+	// Build `api-service`'s dependencies
 
-  // list of dependencies to compile
-  const dependencies = ['../authx_authzed_api', '../user-credentials-cache'];
+	// list of dependencies to compile
+	const dependencies = ['../authx_authzed_api', '../user-credentials-cache', '../issued-jwt-registry'];
 
-  // compile dependencies
-  for (const dependency of dependencies) {
-    let label = `Compiled ${dependency}`;
-    console.time(label);
-    childProcess.execSync('pnpm build', {
-      cwd: path.join(dependency),
-    });
-    console.timeEnd(label);
-  }
+	// compile dependencies
+	for (const dependency of dependencies) {
+		const label = `Compiled ${dependency}`;
+		console.time(label);
+		childProcess.execSync('pnpm build', {
+			cwd: path.join(dependency),
+		});
+		console.timeEnd(label);
+	}
 
-  console.info('Starting authzed podman container');
+	console.info('Starting authzed podman container');
 
-  // current when executing this file is apps/
-  // see execSync command below
-  const podmanCommand = [
-    'podman run --rm',
-    '-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-    '-p 8443:8443',
-    '-d',
-    '--name authzed-container',
-    'authzed/spicedb:latest',
-    'serve-testing',
-    '--http-enabled',
-    '--skip-release-check=true',
-    '--log-level debug',
-    '--load-configs ./schema.zaml',
-  ].join(' ');
+	// current when executing this file is apps/
+	// see execSync command below
+	const podmanCommand = [
+		'podman run --rm',
+		'-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
+		'-p 8443:8443',
+		'-d',
+		'--name authzed-container',
+		'authzed/spicedb:latest',
+		'serve-testing',
+		'--http-enabled',
+		'--skip-release-check=true',
+		'--log-level debug',
+		'--load-configs ./schema.zaml',
+	].join(' ');
 
-  // turn on podman container for authzed
-  childProcess.exec(podmanCommand, {
-    cwd: path.join(__dirname, '..'),
-  }, (err) => {
-    if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
-      console.error('Error starting authzed podman container: Check status with `podman ps`', err);
-    } else {
-      console.info('Authzed podman container started successfully');
-    }
-  });
+	// turn on podman container for authzed
+	childProcess.exec(
+		podmanCommand,
+		{
+			cwd: path.join(__dirname, '..'),
+		},
+		(err) => {
+			if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
+				console.error('Error starting authzed podman container: Check status with `podman ps`', err);
+			} else {
+				console.info('Authzed podman container started successfully');
+			}
+		},
+	);
 
-
-  console.info('Global setup complete');
+	console.info('Global setup complete');
 }

--- a/apps/authx_token_api/package.json
+++ b/apps/authx_token_api/package.json
@@ -8,6 +8,7 @@
 		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
 		"dev": "wrangler dev --port 5051",
 		"test": "vitest",
+		"test:workspace": "vitest run --silent",
 		"build": "wrangler build",
 		"postinstall": "pnpm build"
 	},

--- a/apps/data_channel_gateway/package.json
+++ b/apps/data_channel_gateway/package.json
@@ -1,40 +1,41 @@
 {
-  "name": "@catalyst/data_channel_gateway",
-  "type": "module",
-  "scripts": {
-    "dev": "wrangler dev --port 5052",
-    "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-    "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
-    "test": "vitest"
-  },
-  "dependencies": {
-    "@catalyst/authx_authzed_api": "workspace:^",
-    "@catalyst/authx_token_api": "workspace:^",
-    "@catalyst/data_channel_registrar": "workspace:*",
-    "@catalyst/issued-jwt-registry": "workspace:*",
-    "@catalyst/jwt": "workspace:*",
-    "@catalyst/schema_zod": "workspace:*",
-    "@graphql-tools/stitch": "catalog:",
-    "@graphql-tools/stitching-directives": "^3.0.2",
-    "@graphql-tools/utils": "catalog:",
-    "@graphql-tools/wrap": "catalog:",
-    "graphql": "catalog:",
-    "graphql-yoga": "^5.3.1",
-    "hono": "^4.3.3",
-    "tslog": "catalog:"
-  },
-  "devDependencies": {
-    "@apollo/client": "^3.10.1",
-    "@cloudflare/vitest-pool-workers": "^0.8.15",
-    "@cloudflare/workers-types": "catalog:",
-    "@eslint/js": "catalog:",
-    "@graphql-codegen/typescript-graphql-request": "catalog:",
-    "@urql/core": "catalog:",
-    "gqty": "catalog:",
-    "graphql": "catalog:",
-    "graphql-request": "catalog:",
-    "jose": "^5.2.4",
-    "vitest": "catalog:",
-    "wrangler": "catalog:"
-  }
+    "name": "@catalyst/data_channel_gateway",
+    "type": "module",
+    "scripts": {
+        "dev": "wrangler dev --port 5052",
+        "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
+        "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
+        "test": "vitest",
+        "test:workspace": "vitest run --silent"
+    },
+    "dependencies": {
+        "@catalyst/authx_authzed_api": "workspace:^",
+        "@catalyst/authx_token_api": "workspace:^",
+        "@catalyst/data_channel_registrar": "workspace:*",
+        "@catalyst/issued-jwt-registry": "workspace:*",
+        "@catalyst/jwt": "workspace:*",
+        "@catalyst/schema_zod": "workspace:*",
+        "@graphql-tools/stitch": "catalog:",
+        "@graphql-tools/stitching-directives": "^3.0.2",
+        "@graphql-tools/utils": "catalog:",
+        "@graphql-tools/wrap": "catalog:",
+        "graphql": "catalog:",
+        "graphql-yoga": "^5.3.1",
+        "hono": "^4.3.3",
+        "tslog": "catalog:"
+    },
+    "devDependencies": {
+        "@apollo/client": "^3.10.1",
+        "@cloudflare/vitest-pool-workers": "^0.8.15",
+        "@cloudflare/workers-types": "catalog:",
+        "@eslint/js": "catalog:",
+        "@graphql-codegen/typescript-graphql-request": "catalog:",
+        "@urql/core": "catalog:",
+        "gqty": "catalog:",
+        "graphql": "catalog:",
+        "graphql-request": "catalog:",
+        "jose": "^5.2.4",
+        "vitest": "catalog:",
+        "wrangler": "catalog:"
+    }
 }

--- a/apps/data_channel_registrar/package.json
+++ b/apps/data_channel_registrar/package.json
@@ -8,6 +8,7 @@
     "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
     "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
     "test": "vitest",
+    "test:workspace": "vitest run --silent",
     "dev": "pnpm wrangler dev --port 5053",
     "deploy": "wrangler deploy --minify src/worker.ts",
     "fmt": "prettier --write .",

--- a/apps/issued-jwt-registry/package.json
+++ b/apps/issued-jwt-registry/package.json
@@ -1,30 +1,31 @@
 {
-  "name": "@catalyst/issued-jwt-registry",
-  "version": "0.0.1",
-  "main": "index.ts",
-  "type": "module",
-  "scripts": {
-    "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-    "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
-    "dev": "wrangler dev --port 5054",
-    "test": "vitest",
-    "build": "wrangler build"
-  },
-  "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "catalog:",
-    "@cloudflare/workers-types": "catalog:",
-    "@eslint/js": "catalog:",
-    "@typescript-eslint/eslint-plugin": "^8.29.1",
-    "@typescript-eslint/parser": "^8.29.1",
-    "eslint": "catalog:",
-    "prettier": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:",
-    "wrangler": "catalog:"
-  },
-  "dependencies": {
-    "@catalyst/schema_zod": "workspace:*",
-    "@catalyst/user-credentials-cache": "workspace:*"
-  }
+	"name": "@catalyst/issued-jwt-registry",
+	"version": "0.0.1",
+	"main": "index.ts",
+	"type": "module",
+	"scripts": {
+		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
+		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
+		"dev": "wrangler dev --port 5054",
+		"test": "vitest",
+		"test:workspace": "vitest run --silent",
+		"build": "wrangler build"
+	},
+	"devDependencies": {
+		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@eslint/js": "catalog:",
+		"@typescript-eslint/eslint-plugin": "^8.29.1",
+		"@typescript-eslint/parser": "^8.29.1",
+		"eslint": "catalog:",
+		"prettier": "catalog:",
+		"tsx": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:",
+		"wrangler": "catalog:"
+	},
+	"dependencies": {
+		"@catalyst/schema_zod": "workspace:*",
+		"@catalyst/user-credentials-cache": "workspace:*"
+	}
 }

--- a/apps/organization_matchmaking/package.json
+++ b/apps/organization_matchmaking/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "@catalyst/organization-matchmaking",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-    "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
-    "test": "vitest",
-    "cf-typegen": "wrangler types"
-  },
-  "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "catalog:",
-    "@cloudflare/workers-types": "catalog:",
-    "@eslint/js": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:",
-    "wrangler": "catalog:"
-  }
+	"name": "@catalyst/organization-matchmaking",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
+		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
+		"dev": "wrangler dev",
+		"start": "wrangler dev",
+		"test": "vitest",
+		"test:workspace": "vitest run --silent",
+		"cf-typegen": "wrangler types"
+	},
+	"devDependencies": {
+		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@eslint/js": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:",
+		"wrangler": "catalog:"
+	}
 }

--- a/apps/user-credentials-cache/package.json
+++ b/apps/user-credentials-cache/package.json
@@ -1,22 +1,23 @@
 {
-  "name": "@catalyst/user-credentials-cache",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-    "deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
-    "cf-typegen": "wrangler types",
-    "build": "wrangler build",
-    "test": "vitest"
-  },
-  "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "catalog:",
-    "@cloudflare/workers-types": "catalog:",
-    "@eslint/js": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:",
-    "wrangler": "catalog:"
-  }
+	"name": "@catalyst/user-credentials-cache",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
+		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
+		"dev": "wrangler dev",
+		"start": "wrangler dev",
+		"cf-typegen": "wrangler types",
+		"build": "wrangler build",
+		"test": "vitest",
+		"test:workspace": "vitest run --silent"
+	},
+	"devDependencies": {
+		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@eslint/js": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:",
+		"wrangler": "catalog:"
+	}
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
-import pluginJs from '@eslint/js'
-import tseslint from 'typescript-eslint'
-import pluginReact from 'eslint-plugin-react'
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+import pluginJs from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import pluginReact from 'eslint-plugin-react';
+import tseslint from 'typescript-eslint';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -23,14 +23,7 @@ export default [
         },
     },
     {
-        ignores: [
-            'coverage',
-            '**/public',
-            '**/dist',
-            'pnpm-lock.yaml',
-            'pnpm-workspace.yaml',
-            '**/.wrangler/**',
-        ],
+        ignores: ['coverage', '**/public', '**/dist', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '**/.wrangler/**'],
     },
     eslintPluginPrettierRecommended,
-]
+];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "main": "index.js",
     "scripts": {
-        "test": "pnpm run -r test",
+        "test": "pnpm run -r test:workspace",
         "sim": "pnpm run -r sim",
         "ls": "pnpm ls -r --json --long --depth 6 --prod >> ./pnpmls.json",
         "deploymentPreview": "pnpm run -r deploymentPreview",
@@ -17,6 +17,7 @@
     "devDependencies": {
         "@commitlint/cli": "^19.8.0",
         "@commitlint/config-conventional": "^19.8.0",
+        "@eslint/js": "catalog:",
         "@types/node": "^20",
         "bun": "^1.1.7",
         "eslint": "^9.23.0",

--- a/packages/schema_zod/tsconfig.json
+++ b/packages/schema_zod/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "module": "ESNext",
-    "target": "ESNext",
-    "moduleResolution": "Node",
-    "strict": true,
-    "types": ["@cloudflare/workers-types/experimental"],
-  },
-  "include": ["./authzed/**/*", "./catalyst/**/*", "index.ts"],
-  "exclude": []
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "module": "ESNext",
+        "target": "ESNext",
+        "moduleResolution": "Node",
+        "strict": true,
+        "types": []
+    },
+    "include": ["./authzed/**/*", "./catalyst/**/*", "index.ts"],
+    "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.8.0
         version: 19.8.0
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.25.1
       '@types/node':
         specifier: ^20
         version: 20.17.32
@@ -15798,8 +15801,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.25.1(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@9.25.1(jiti@2.4.2))
@@ -15901,21 +15904,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@8.1.1)
-      eslint: 9.25.1(jiti@2.4.2)
-      get-tsconfig: 4.10.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.13
-      unrs-resolver: 1.7.2
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -15942,14 +15930,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -15999,7 +15987,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -16010,7 +15998,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### TL;DR

- Added a silent test mode for workspace testing and updated code formatting configuration. 
- `test:workspace` script to all `/package.json` files that runs all supported apps.
- new test dependency in `global-setup.ts` for vitest-testing of `apps/auth_token_api`

### What changed?
- Updated the root `package.json` to use the new silent test mode for workspace testing
- Modified Prettier configuration to include `printWidth: 120` and `proseWrap: "preserve"`
- Changed `semicolon` setting from `false` to `true` in Prettier config
- Added `issued-jwt-registry` to the dependencies list in global-setup.ts
- Fixed code formatting on files on this commit
- Fixed a TODO comment in data_channel_gateway tests

### How to test?

1. Run `pnpm test`  on `<rootDir>` to verify the silent test mode works across all packages
2. Check that code formatting is consistent with the new Prettier rules
3. Verify that the `global-setup.ts` correctly builds all dependencies including `issued-jwt-registry`

### Why make this change?

This change improves the developer experience by:
1. Making workspace-level testing more concise with silent output
2. Standardizing code formatting across the project with consistent rules
3. Ensuring all necessary dependencies are properly built during setup
4. Fixing inconsistencies in the codebase to follow the same style guidelines