### PR TITLE
feat: add no ui option to startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,30 @@ While `fetch` never took off, we are hoping that our design tenets do.
 
 Our design tenets are:
 
-* **Secure**: Built with security-first principles using zero trust architecture
-* **Industry standard and open protocols**: Using proven technologies like GraphQL and JWT
-* **Interoperability**: Works across systems, databases, and tech organizations
-* **Open source**: Transparent and extensible
-* **Internet scale**: Designed to run globally at the edge
+- **Secure**: Built with security-first principles using zero trust architecture
+- **Industry standard and open protocols**: Using proven technologies like GraphQL and JWT
+- **Interoperability**: Works across systems, databases, and tech organizations
+- **Open source**: Transparent and extensible
+- **Internet scale**: Designed to run globally at the edge
 
 To achieve this we use:
 
-* **GraphQL** - A flexible, well understood, data schema and API pattern
-* **GraphQL Stitching** - Create a single endpoint to access all data without having to move the data
-* **Cloudflare Workers** - Code designed to be distributed running all over the world at once
-* **Zanzibar-inspired RelBAC** - Real-time data sharing security model
-* **Asymmetric JWTs** - Create secrets at the core and validate at the edge
-* **Zero Trust Architecture** - Never trust, always verify approach to security at every level
+- **GraphQL** - A flexible, well understood, data schema and API pattern
+- **GraphQL Stitching** - Create a single endpoint to access all data without having to move the data
+- **Cloudflare Workers** - Code designed to be distributed running all over the world at once
+- **Zanzibar-inspired RelBAC** - Real-time data sharing security model
+- **Asymmetric JWTs** - Create secrets at the core and validate at the edge
+- **Zero Trust Architecture** - Never trust, always verify approach to security at every level
 
 ## How Does the Federated Data Grid Work
 
 Catalyst is a stack of tightly coupled technologies that can be deployed on any platform. Catalyst provides:
 
-* Patterns for exposing local data sets and workloads to a (logically) central place
-* Identity and access control patterns that are used across the platform
-* Technology anyone can deploy
+- Patterns for exposing local data sets and workloads to a (logically) central place
+- Identity and access control patterns that are used across the platform
+- Technology anyone can deploy
 
-Catalyst works by having a (logically) central gateway and identity/access control stack that is operated by a trusted entity (the hub). 
+Catalyst works by having a (logically) central gateway and identity/access control stack that is operated by a trusted entity (the hub).
 
 Organizations are enrolled by the Catalyst operator and once onboarded org admins have complete control of their org which includes provisioning new data channels and minting API keys.
 
@@ -47,9 +47,9 @@ When setting up a data channel, a data custodian runs through the connection set
 
 Catalyst is an organization-based platform with clear role definitions:
 
-* **Users**: Can access data channels and create API keys
-* **Data Custodians**: Can create/manage data channels and partnership sharing
-* **Org Admins**: Can manage roles and invite users to the organization
+- **Users**: Can access data channels and create API keys
+- **Data Custodians**: Can create/manage data channels and partnership sharing
+- **Org Admins**: Can manage roles and invite users to the organization
 
 ### Authentication and Authorization Flow
 
@@ -74,7 +74,7 @@ Catalyst implements a zero trust approach to security, where identity verificati
 1. **Partnership Request**: One organization sends an invitation to another
 2. **Partnership Acceptance**: The receiving organization accepts the invitation
 3. **Data Channel Sharing**: Data custodians enable access to specific channels
-4. **Access Control**: Users from partner organizations can access shared channels   
+4. **Access Control**: Users from partner organizations can access shared channels
 
 ## Security Considerations
 
@@ -87,6 +87,12 @@ Catalyst is built with security as a foundational principle:
 - **Access Control**: Fine-grained permissions based on user roles
 - **Transport Security**: All communication over HTTPS
 - **Edge Security**: Validation at the edge through Cloudflare Workers
+
+## Startup
+
+To spin the app up, it's recommended to use the `run_local_dev.sh` script found in the root of the repository. This will loop through the various containers found in the apps directory and spin each one up via podman. The script can be run with the following flags:
+
+- `--no-ui`: avoids running the client and instead run all of the backend services standalone.
 
 ## Learn More
 

--- a/apps/catalyst-ui-worker/wrangler.jsonc
+++ b/apps/catalyst-ui-worker/wrangler.jsonc
@@ -14,26 +14,72 @@
     },
     "minify": true,
     "services": [
-        { "binding": "WORKER_SELF_REFERENCE", "service": "catalyst-ui-worker" },
-        { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry" },
-        { "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API", "service": "data_channel_registrar" },
-        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api" },
-        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api" },
-        { "binding": "USER_CREDS_CACHE", "service": "user-credentials-cache" },
-        { "binding": "ORGANIZATION_MATCHMAKING", "service": "organization-matchmaking" },
+        {
+            "binding": "WORKER_SELF_REFERENCE",
+            "service": "catalyst-ui-worker",
+        },
+        {
+            "binding": "ISSUED_JWT_WORKER",
+            "service": "issued-jwt-registry",
+        },
+        {
+            "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API",
+            "service": "data_channel_registrar",
+        },
+        {
+            "binding": "AUTHX_TOKEN_API",
+            "service": "authx_token_api",
+        },
+        {
+            "binding": "AUTHX_AUTHZED_API",
+            "service": "authx_authzed_api",
+        },
+        {
+            "binding": "USER_CREDS_CACHE",
+            "service": "user-credentials-cache",
+        },
+        {
+            "binding": "ORGANIZATION_MATCHMAKING",
+            "service": "organization-matchmaking",
+        },
     ],
-
     "env": {
         "preview": {
-            "routes": [{ "pattern": "preview.orbisops.io", "custom_domain": true }],
+            "routes": [
+                {
+                    "pattern": "preview.orbisops.io",
+                    "custom_domain": true,
+                },
+            ],
             "services": [
-                { "binding": "WORKER_SELF_REFERENCE", "service": "catalyst-ui-worker-preview" },
-                { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-preview" },
-                { "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API", "service": "data_channel_registrar-preview" },
-                { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-preview" },
-                { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-preview" },
-                { "binding": "USER_CREDS_CACHE", "service": "user-credentials-cache-preview" },
-                { "binding": "ORGANIZATION_MATCHMAKING", "service": "organization-matchmaking-preview" },
+                {
+                    "binding": "WORKER_SELF_REFERENCE",
+                    "service": "catalyst-ui-worker-preview",
+                },
+                {
+                    "binding": "ISSUED_JWT_WORKER",
+                    "service": "issued-jwt-registry-preview",
+                },
+                {
+                    "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API",
+                    "service": "data_channel_registrar-preview",
+                },
+                {
+                    "binding": "AUTHX_TOKEN_API",
+                    "service": "authx_token_api-preview",
+                },
+                {
+                    "binding": "AUTHX_AUTHZED_API",
+                    "service": "authx_authzed_api-preview",
+                },
+                {
+                    "binding": "USER_CREDS_CACHE",
+                    "service": "user-credentials-cache-preview",
+                },
+                {
+                    "binding": "ORGANIZATION_MATCHMAKING",
+                    "service": "organization-matchmaking-preview",
+                },
             ],
         },
         // "staging": {
@@ -77,7 +123,6 @@
         //   { "binding": "USER_CREDS_CACHE", "service": "user-credentials-cache-demo" },
         //   { "binding": "ORGANIZATION_MATCHMAKING", "service": "organization-matchmaking-demo" }
         // ]
-
         // We don't have these setup up yet
         // "services": [
         //   { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-production" },

--- a/run_local_dev.sh
+++ b/run_local_dev.sh
@@ -103,6 +103,22 @@ progress_bar() {
 
 # --- Configuration ---
 APPS_DIR="apps"
+NO_UI=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --no-ui)
+      NO_UI=true
+      shift
+      ;;
+    *)
+      print_error "Unknown option: $1"
+      print_error "Usage: $0 [--no-ui]"
+      exit 1
+      ;;
+  esac
+done
 
 # Define the startup order based on dependencies (Management -> Control -> Data -> UI/CLI)
 APP_ORDER=(
@@ -113,10 +129,14 @@ APP_ORDER=(
   "data_channel_registrar"   # Control: Manages data channel discovery
   "organization_matchmaking" # Control: Manages organization partnerships
   "data_channel_gateway"     # Data: Federates data channels
-  # "catalyst-ui-worker"       # Management: Web interface
   # "datachannel-next"       # Data: Example data channel implementation
   # "catalyst_cli"           # Management: CLI tool (usually not run continuously in dev)
 )
+
+# Add UI worker if --no-ui flag is not set
+if [ "$NO_UI" = false ]; then
+  APP_ORDER+=("catalyst-ui-worker")  # Management: Web interface
+fi
 
 DEFAULT_DEV_COMMAND="pnpm run dev"
 SLEEP_DURATION=2 # Seconds to wait between starting apps


### PR DESCRIPTION
### TL;DR

Added a `--no-ui` flag to the local development script to allow running the backend services without the UI worker.

### What changed?

- Added command line argument parsing to `run_local_dev.sh`
- Implemented a `--no-ui` flag that, when specified, excludes the UI worker from the startup process
- Moved the UI worker from being commented out in the app order list to being conditionally added based on the flag
- Added usage information that displays when invalid arguments are provided

### How to test?

1. Run the script normally to start all services including the UI:
   ```
   ./run_local_dev.sh
   ```

2. Run the script with the new flag to start only backend services:
   ```
   ./run_local_dev.sh --no-ui
   ```

3. Verify that when using `--no-ui`, the catalyst-ui-worker service does not start

### Why make this change?

This change provides developers with more flexibility when working on the local development environment. When focusing on backend services, developers can now choose to run only the necessary components without starting the UI worker, which can save resources and simplify the development workflow.