### PR TITLE
test(organization-matchmaking): add coverage

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 pnpm lint-staged
 
-# TODO: Uncomment this once we get the tests working
 pnpm test

--- a/apps/organization_matchmaking/package.json
+++ b/apps/organization_matchmaking/package.json
@@ -3,20 +3,20 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
 		"test": "vitest",
 		"test:workspace": "vitest run --silent",
+		"test:coverage": "vitest run --coverage",
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "catalog:",
-		"@cloudflare/workers-types": "catalog:",
-		"@eslint/js": "catalog:",
-		"typescript": "catalog:",
-		"vitest": "catalog:",
-		"wrangler": "catalog:"
+		"@cloudflare/vitest-pool-workers": "^0.8.23",
+		"@cloudflare/workers-types": "^4.20250430.0",
+		"@eslint/js": "9.25.1",
+		"@vitest/coverage-istanbul": "^3.1.3",
+		"typescript": "^5.8.3",
+		"vitest": "^3.1.3",
+		"wrangler": "^4.14.0"
 	}
 }

--- a/apps/organization_matchmaking/vitest.config.ts
+++ b/apps/organization_matchmaking/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineWorkersConfig({
 				wrangler: { configPath: './wrangler.jsonc' },
 				singleWorker: false,
 				isolatedStorage: false,
+
 				miniflare: {
 					unsafeEphemeralDurableObjects: true,
 					durable_objects: {
@@ -44,6 +45,20 @@ export default defineWorkersConfig({
 					],
 				},
 			},
+		},
+		coverage: {
+			provider: 'istanbul',
+			reporter: ['text', 'json', 'html'],
+			exclude: [
+				'**/node_modules/**',
+				'**/dist/**',
+				'**/test/**',
+				'**/*.{test,spec}.?(c|m)[jt]s?(x)',
+				'**/wrangler.jsonc',
+				'**/vitest.config.*',
+				'**/.wrangler/**',
+				'**/global-setup.ts',
+			],
 		},
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,23 +814,26 @@ importers:
   apps/organization_matchmaking:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
-        specifier: 'catalog:'
-        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
+        specifier: ^0.8.23
+        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       '@cloudflare/workers-types':
-        specifier: 'catalog:'
+        specifier: ^4.20250430.0
         version: 4.20250430.0
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: 9.25.1
         version: 9.25.1
+      '@vitest/coverage-istanbul':
+        specifier: ^3.1.3
+        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       typescript:
-        specifier: 'catalog:'
+        specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: 'catalog:'
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.1.3
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
       wrangler:
-        specifier: 'catalog:'
-        version: 4.13.2(@cloudflare/workers-types@4.20250430.0)
+        specifier: ^4.14.0
+        version: 4.14.0(@cloudflare/workers-types@4.20250430.0)
 
   apps/user-credentials-cache:
     devDependencies:


### PR DESCRIPTION
### TL;DR

Added test coverage configuration for the organization matchmaking app.

### What changed?

- Updated package dependencies in organization_matchmaking to use specific versions instead of catalog references
- Added a new `test:coverage` script to the organization_matchmaking package.json
- Added Istanbul coverage configuration to vitest.config.ts with appropriate exclusion patterns
- Removed deployment scripts for demo and staging environments

### How to test?

1. Run `pnpm test:coverage` in the organization_matchmaking directory to verify coverage reporting works
2. Make a commit to verify that tests now run as part of the pre-commit hook
3. Check that the coverage reports are generated in HTML, JSON, and text formats

### Why make this change?

This change improves the development workflow by ensuring tests run before each commit, preventing broken code from being committed. Adding test coverage configuration helps track code quality and identify areas that need more testing. Using specific dependency versions instead of catalog references provides better version control and reproducibility.