### PR TITLE
feat(secure-token): added initial valid implementation for secure exchange of ctTokens to producers

### DIFF
--- a/apps/authx_token_api/global-setup.ts
+++ b/apps/authx_token_api/global-setup.ts
@@ -6,7 +6,7 @@ export default function () {
 	// Build `api-service`'s dependencies
 
 	// list of dependencies to compile
-	const dependencies = ['../authx_authzed_api', '../user-credentials-cache', '../issued-jwt-registry'];
+	const dependencies = ['../authx_authzed_api', '../user-credentials-cache', '../issued-jwt-registry', '../data_channel_registrar'];
 
 	// compile dependencies
 	for (const dependency of dependencies) {

--- a/apps/authx_token_api/src/env.d.ts
+++ b/apps/authx_token_api/src/env.d.ts
@@ -1,6 +1,7 @@
 export interface Env {
 	KEY_PROVIDER: DurableObjectNamespace<import('./durable_object_security_module').JWTKeyProvider>;
-	AUTHZED: Service<import('../../authx_authzed_api/src/index').default>
-	USERCACHE: Service<import('../../authx_user_cache/src/index').default>
-	ISSUED_JWT_REGISTRY_WORKER: Service<import('../../authx_issued_jwt_registry/src/index').default>
+	AUTHZED: Service<import('../../authx_authzed_api/src/index').default>;
+	USERCACHE: Service<import('../../authx_user_cache/src/index').default>;
+	ISSUED_JWT_REGISTRY_WORKER: Service<import('../../authx_issued_jwt_registry/src/index').default>;
+	DATA_CHANNEL_REGISTRAR: Service<import('../../data_channel_registrar/src/worker').default>;
 }

--- a/apps/authx_token_api/src/index.ts
+++ b/apps/authx_token_api/src/index.ts
@@ -155,7 +155,7 @@ export default class JWTWorker extends WorkerEntrypoint<Env> {
 		if (claims?.length === 0) {
 			return JWTSigningResponse.parse({
 				success: false,
-				error: 'invalid claimes error: JWT creating request must contain at least one claim',
+				error: 'invalid claims error: JWT creating request must contain at least one claim',
 			});
 		}
 

--- a/apps/authx_token_api/src/index.ts
+++ b/apps/authx_token_api/src/index.ts
@@ -1,14 +1,16 @@
-import { DurableObjectNamespace } from '@cloudflare/workers-types';
 import { WorkerEntrypoint } from 'cloudflare:workers';
-import { JWTRotateResponse, JWTSigningRequest, JWTSigningResponse, Token, User } from '../../../packages/schema_zod';
-import { JWTKeyProvider } from './durable_object_security_module';
+import {
+	DataChannel,
+	DEFAULT_STANDARD_DURATIONS,
+	JWTRotateResponse,
+	JWTSigningRequest,
+	JWTSigningResponse,
+	Token,
+	User,
+} from '../../../packages/schema_zod';
 import { Env } from './env';
+import { JWTPayload } from 'jose';
 export { JWTKeyProvider } from './durable_object_security_module';
-
-type Bindings = {
-	// @ts-ignore
-	KEY_PROVIDER: DurableObjectNamespace<JWTKeyProvider>;
-};
 
 export default class JWTWorker extends WorkerEntrypoint<Env> {
 	async getPublicKey(keyNamespace: string = 'default') {
@@ -117,6 +119,86 @@ export default class JWTWorker extends WorkerEntrypoint<Env> {
 			success: true,
 			token: jwt.token,
 			expiration: jwt.expiration,
+		});
+	}
+
+	/**
+	 * Sign a single use JWT for a data channel
+	 * @param jwtRequest
+	 * @param expiresIn
+	 * @param token
+	 * @param keyNamespace
+	 * @returns
+	 */
+	async signSingleUseJWT(claim: string, token: Token, keyNamespace: string = 'default'): Promise<JWTSigningResponse> {
+		if (!token.catalystToken) {
+			console.error('need a catalyst token to sign a JWT');
+			return JWTSigningResponse.parse({
+				success: false,
+				error: 'catalyst did not recieve a catalyst token',
+			});
+		}
+		const id = this.env.KEY_PROVIDER.idFromName(keyNamespace);
+		const stub = this.env.KEY_PROVIDER.get(id);
+
+		// decode the CT token
+		const decodedToken: { success: boolean; payload: JWTPayload } = await stub.decodeToken(token.catalystToken);
+		if (!decodedToken?.payload || !decodedToken.payload.claims) {
+			return JWTSigningResponse.parse({
+				success: false,
+				error: 'error decoding catalyst token',
+			});
+		}
+
+		const claims = decodedToken.payload.claims;
+		// @ts-expect-error: claims is not typed, but exists in the JWT payload
+		if (claims?.length === 0) {
+			return JWTSigningResponse.parse({
+				success: false,
+				error: 'invalid claimes error: JWT creating request must contain at least one claim',
+			});
+		}
+
+		// TODO: check  against the data channel registrar??? Ask team,
+		// Note: introduces new dependency on AUTH TOKEN API, removes it from the data channel gateway tho
+
+		// data channels that this Catalyst Token Has Access to
+		const validDataChannels = await this.env.DATA_CHANNEL_REGISTRAR.list(keyNamespace, token);
+
+		if (!validDataChannels.success) {
+			console.error(validDataChannels.error);
+			// return a vague error message for security purposes
+			return { success: false, error: 'no resources found' };
+		}
+
+		// data channels that this Catalyst Token Has Access to
+		const readableDataChannels = DataChannel.safeParse(validDataChannels.data).success
+			? [DataChannel.parse(validDataChannels.data)]
+			: DataChannel.array().parse(validDataChannels.data);
+
+		const dataChannel = readableDataChannels.find((dataChannel) => dataChannel.id === claim);
+
+		if (!dataChannel) {
+			return JWTSigningResponse.parse({
+				success: false,
+				error: 'no resources found',
+			});
+		}
+
+		// create a single use JWT for this specific data channel
+		const singleUseJWTs = await stub.signJWT(
+			{
+				entity: decodedToken.payload.sub!,
+				claims: [dataChannel.id],
+				expiresIn: 5 * DEFAULT_STANDARD_DURATIONS.M,
+			},
+			5 * DEFAULT_STANDARD_DURATIONS.M,
+		);
+
+		return JWTSigningResponse.parse({
+			success: true,
+			token: singleUseJWTs.token,
+			expiration: singleUseJWTs.expiration,
 		});
 	}
 

--- a/apps/authx_token_api/vitest.config.ts
+++ b/apps/authx_token_api/vitest.config.ts
@@ -1,8 +1,7 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 import path from 'path';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const validUsers: Record<string, any> = {
+const validUsers: Record<string, { email: string; custom: unknown }> = {
 	'admin-cf-token': {
 		email: 'email@example.com',
 		custom: {
@@ -82,6 +81,37 @@ export default defineWorkersConfig({
 						KEY_PROVIDER: 'JWTKeyProvider',
 					},
 					workers: [
+						{
+							name: 'data_channel_registrar',
+							modules: true,
+							modulesRoot: path.resolve('../data_channel_registrar'),
+							scriptPath: path.resolve('../data_channel_registrar/dist/worker.js'),
+							compatibilityDate: '2025-04-01',
+							compatibilityFlags: ['nodejs_compat'],
+							entrypoint: 'RegistrarWorker',
+							durableObjects: {
+								DO: 'Registrar',
+							},
+							serviceBindings: {
+								AUTHX_TOKEN_API: 'authx_token_api',
+								AUTHZED: 'authx_authzed_api',
+							},
+						},
+						{
+							name: 'authx_token_api',
+							modules: true,
+							modulesRoot: path.resolve('../authx_token_api'),
+							scriptPath: path.resolve('../authx_token_api/dist/index.js'),
+							compatibilityDate: '2025-04-01',
+							compatibilityFlags: ['nodejs_compat'],
+							unsafeEphemeralDurableObjects: true,
+							durableObjects: {
+								KEY_PROVIDER: 'JWTKeyProvider',
+							},
+							serviceBindings: {
+								DATA_CHANNEL_REGISTRAR: 'data_channel_registrar',
+							},
+						},
 						{
 							name: 'authx_authzed_api',
 							modules: true,

--- a/apps/authx_token_api/wrangler.jsonc
+++ b/apps/authx_token_api/wrangler.jsonc
@@ -11,27 +11,28 @@
 	"keep_vars": true,
 	"send_metrics": false,
 	"observability": {
-		"enabled": true
+		"enabled": true,
 	},
 
 	// Service bindings
 	"services": [
 		{ "binding": "AUTHZED", "service": "authx_authzed_api" },
-		{ "binding": "USERCACHE", "service": "user-credentials-cache" }
+		{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar" },
+		{ "binding": "USERCACHE", "service": "user-credentials-cache" },
 	],
 
 	// Durable Objects
 	// https://developers.cloudflare.com/durable-objects/
 	"durable_objects": {
-		"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }]
+		"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
 	},
 
 	// Migrations
 	"migrations": [
 		{
 			"tag": "v1", // Should be unique for each entry
-			"new_classes": ["JWTKeyProvider"]
-		}
+			"new_classes": ["JWTKeyProvider"],
+		},
 	],
 
 	// ============================ STAGING VALUES =============================
@@ -39,38 +40,42 @@
 		"preview": {
 			"services": [
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-preview" },
-				{ "binding": "USERCACHE", "service": "user-credentials-cache-preview" }
+				{ "binding": "USERCACHE", "service": "user-credentials-cache-preview" },
+				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-preview" },
 			],
 			"durable_objects": {
-				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }]
-			}
+				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
+			},
 		},
 		"staging": {
 			"services": [
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-staging" },
-				{ "binding": "USERCACHE", "service": "user-credentials-cache-staging" }
+				{ "binding": "USERCACHE", "service": "user-credentials-cache-staging" },
+				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-staging" },
 			],
 			"durable_objects": {
-				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }]
-			}
+				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
+			},
 		},
 		"demo": {
 			"services": [
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-demo" },
-				{ "binding": "USERCACHE", "service": "user-credentials-cache-demo" }
+				{ "binding": "USERCACHE", "service": "user-credentials-cache-demo" },
+				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-demo" },
 			],
 			"durable_objects": {
-				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }]
-			}
+				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
+			},
 		},
 		"production": {
 			"services": [
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-production" },
-				{ "binding": "USERCACHE", "service": "user-credentials-cache-production" }
+				{ "binding": "USERCACHE", "service": "user-credentials-cache-production" },
+				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-production" },
 			],
 			"durable_objects": {
-				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }]
-			}
-		}
-	}
+				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
+			},
+		},
+	},
 }

--- a/apps/data_channel_gateway/src/env.d.ts
+++ b/apps/data_channel_gateway/src/env.d.ts
@@ -1,8 +1,5 @@
-import RegistrarWorker from "@catalyst/data_channel_registrar/src/worker"
-import JWTWorker from '@catalyst/authx_token_api/src';
-import JWTRegistry from "../../issued-jwt-registry/src"
-export interface Env  {
-  DATA_CHANNEL_REGISTRAR: Service<RegistrarWorker>
-  AUTHX_TOKEN_API: Service<JWTWorker>
-  JWT_REGISTRY: Service<JWTRegistry>
+export interface Env {
+    DATA_CHANNEL_REGISTRAR: Service<import('@catalyst/data_channel_registrar/src/worker').default>;
+    AUTHX_TOKEN_API: Service<import('@catalyst/authx_token_api/src').default>;
+    JWT_REGISTRY: Service<import('../../issued-jwt-registry/src').default>;
 }

--- a/apps/data_channel_gateway/src/index.ts
+++ b/apps/data_channel_gateway/src/index.ts
@@ -170,7 +170,7 @@ app.use('/graphql', async (ctx) => {
     if (!dataChannelsSingleUseTokens.success) {
         return ctx.json(
             {
-                error: 'not resources found',
+                error: 'no resources found',
             },
             403
         );

--- a/apps/data_channel_gateway/src/index.ts
+++ b/apps/data_channel_gateway/src/index.ts
@@ -1,190 +1,187 @@
-import { grabTokenInHeader } from "@catalyst/jwt";
-import { DataChannel, Token } from "@catalyst/schema_zod";
-import { stitchSchemas } from "@graphql-tools/stitch";
-import { stitchingDirectives } from "@graphql-tools/stitching-directives";
-import {
-  AsyncExecutor,
-  isAsyncIterable,
-  type Executor,
-} from "@graphql-tools/utils";
-import { buildSchema, parse, print } from "graphql";
-import { createYoga } from "graphql-yoga";
-import { Hono } from "hono";
-import { Env } from "./env";
+import { grabTokenInHeader } from '@catalyst/jwt';
+import { Token } from '@catalyst/schema_zod';
+import { stitchSchemas } from '@graphql-tools/stitch';
+import { stitchingDirectives } from '@graphql-tools/stitching-directives';
+import { AsyncExecutor, isAsyncIterable, type Executor } from '@graphql-tools/utils';
+import { buildSchema, parse, print } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+import { Hono } from 'hono';
+import { Env } from './env';
+import { Variables } from './types';
+import { generateSingleUseCatalystTokens } from './tokenGenerators';
+
 // // https://github.com/ardatan/schema-stitching/blob/master/examples/stitching-directives-sdl/src/gateway.ts
 export async function fetchRemoteSchema(executor: Executor) {
-  // throw new Error();
-  const result = await executor({
-    document: parse(/* GraphQL */ `
-      {
-        _sdl
-      }
-    `),
-  });
-  if (isAsyncIterable(result)) {
-    throw new Error("Expected executor to return a single result");
-  }
-  return buildSchema(result.data._sdl);
+    // throw new Error();
+    const result = await executor({
+        document: parse(/* GraphQL */ `
+            {
+                _sdl
+            }
+        `),
+    });
+    if (isAsyncIterable(result)) {
+        throw new Error('Expected executor to return a single result');
+    }
+    return buildSchema(result.data._sdl);
 }
-//
-// https://github.com/ardatan/schema-stitching/blob/master/examples/combining-local-and-remote-schemas/src/gateway.ts
-export async function makeGatewaySchema(
-  endpoints: { endpoint: string }[],
-  token: string
-) {
-  console.log("makeGatewaySchema");
-  const { stitchingDirectivesTransformer } = stitchingDirectives();
-  // Make remote executors:
-  // these are simple functions that query a remote GraphQL API for JSON.
-  const remoteExecutors = endpoints.map(({ endpoint }) => {
-    const executor: AsyncExecutor = async ({
-      document,
-      variables,
-      operationName,
-      extensions,
-    }) => {
-      const query = print(document);
-      const fetchResult = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-          Authorization: `Bearer ${token}`,
-          //  Authorization: executorRequest?.context?.authHeader,
-        },
-        body: JSON.stringify({ query, variables, operationName, extensions }),
-      });
-      return fetchResult.json();
-    };
-    return executor;
-  });
-  //
-  console.log("before promise all");
-  const subschemas = Promise.allSettled(
-    remoteExecutors.map(async (exec) => {
-      return {
-        schema: await fetchRemoteSchema(exec),
-        executor: exec,
-      };
-    })
-  ).then(results => {
-    // Filter out failed producers and only use successful ones
-    return results
-      .filter(result => result.status === 'fulfilled')
-      .map(result => (result as PromiseFulfilledResult<any>).value);
-  });
-  return stitchSchemas({
-    subschemas: await subschemas,
-    subschemaConfigTransforms: [stitchingDirectivesTransformer],
-    typeDefs: "type Query { health: String! }",
-    resolvers: {
-      Query: {
-        health: () => "OK",
-      },
-    },
-  });
-}
-//
 
-type Variables = {
-  claims: string[];
-  "catalyst-token": string;
-};
+// https://github.com/ardatan/schema-stitching/blob/master/examples/combining-local-and-remote-schemas/src/gateway.ts
+export async function makeGatewaySchema(endpointsInfo: { endpoint: string; singleUseToken: string }[]) {
+    console.log('makeGatewaySchema');
+
+    const { stitchingDirectivesTransformer } = stitchingDirectives();
+    // Make remote executors:
+    // these are simple functions that query a remote GraphQL API for JSON.
+    const remoteExecutors = endpointsInfo.map(({ endpoint, singleUseToken }) => {
+        // generate a single use token for the data channel
+        const executor: AsyncExecutor = async ({ document, variables, operationName, extensions }) => {
+            const query = print(document);
+            const fetchResult = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: `Bearer ${singleUseToken}`,
+                    //  Authorization: executorRequest?.context?.authHeader,
+                },
+                body: JSON.stringify({ query, variables, operationName, extensions }),
+            });
+            return fetchResult.json();
+        };
+        return executor;
+    });
+    //
+    console.log('before promise all');
+    const subschemas = Promise.allSettled(
+        remoteExecutors.map(async (exec) => {
+            return {
+                schema: await fetchRemoteSchema(exec),
+                executor: exec,
+            };
+        })
+    ).then((results) => {
+        // Filter out failed producers and only use successful ones
+        return (
+            results
+                .filter((result) => result.status === 'fulfilled')
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .map((result) => (result as PromiseFulfilledResult<any>).value)
+        );
+    });
+    return stitchSchemas({
+        subschemas: await subschemas,
+        subschemaConfigTransforms: [stitchingDirectivesTransformer],
+        typeDefs: 'type Query { health: String! }',
+        resolvers: {
+            Query: {
+                health: () => 'OK',
+            },
+        },
+    });
+}
+//
 
 const app = new Hono<{
-  Bindings: Env & Record<string, any>;
-  Variables: Variables;
+    Bindings: Env;
+    Variables: Variables;
 }>();
+
 // this should be public
-app.use("/.well-known/jwks.json", async (c) => {
-  const jwks = await c.env.AUTHX_TOKEN_API.getPublicKeyJWK();
-  console.log(jwks);
-  return c.json(jwks, 200);
+app.use('/.well-known/jwks.json', async (c) => {
+    const jwks = await c.env.AUTHX_TOKEN_API.getPublicKeyJWK();
+    console.log(jwks);
+    return c.json(jwks, 200);
 });
 
 app.use(async (c, next) => {
-  console.log("in da gtwy");
+    console.log('in da gtwy');
 
-  const [token, error] = grabTokenInHeader(c.req.header("Authorization"));
-  if (!token)
-    console.error({
-      tokenError: token,
-      error: "invalid token before createYoga",
-    });
-  else console.error("token should be working");
+    const [token, error] = grabTokenInHeader(c.req.header('Authorization'));
+    if (!token)
+        console.error({
+            tokenError: token,
+            error: 'invalid token before createYoga',
+        });
+    else console.error('token should be working');
 
-  if (error) {
-    return c.json(
-      {
-        error: error.msg,
-      },
-      error.status
-    );
-  }
-  if (token == "") {
-    return c.json(
-      {
-        error: "JWT Invalid",
-      },
-      403
-    );
-  }
+    if (error) {
+        return c.json(
+            {
+                error: error.msg,
+            },
+            error.status
+        );
+    }
+    if (token == '') {
+        return c.json(
+            {
+                error: 'JWT Invalid',
+            },
+            403
+        );
+    }
 
-  const {
-    valid,
-    entity,
-    claims,
-    jwtId,
-    error: ValidError,
-  } = await c.env.AUTHX_TOKEN_API.validateToken(token);
-  console.log(valid, entity, claims, jwtId, error);
-  if (!valid || ValidError) {
-    return c.json({ message: "Token validation failed" }, 403);
-  }
+    const { valid, entity, claims, jwtId, error: ValidError } = await c.env.AUTHX_TOKEN_API.validateToken(token);
+    console.log(valid, entity, claims, jwtId, error);
+    if (!valid || ValidError) {
+        return c.json({ message: 'Token validation failed' }, 403);
+    }
 
-  if (!jwtId && !(await c.env.JWT_REGISTRY.isOnRevocationList(jwtId))) {
-    return c.json({ message: "Token has been revoked" }, 403);
-  }
+    if (!jwtId && !(await c.env.JWT_REGISTRY.isOnRevocationList(jwtId))) {
+        return c.json({ message: 'Token has been revoked' }, 403);
+    }
 
-  c.set("claims", claims);
-  c.set("catalyst-token", token);
-  // we good
-  await next();
+    c.set('claims', claims);
+    c.set('catalyst-token', token);
+    // we good
+    await next();
 
-  // we can add claims but do not need to enforce them here
+    // we can add claims but do not need to enforce them here
 });
-app.use("/graphql", async (ctx) => {
-  //console.log({context: ctx})
 
-  const token = Token.safeParse({
-    catalystToken: ctx.get("catalyst-token"),
-  });
+app.use('/graphql', async (ctx) => {
+    //console.log({context: ctx})
+    const token = Token.safeParse({
+        catalystToken: ctx.get('catalyst-token'),
+    });
 
-  if (!token.success) {
-    console.error(token.error);
-    return ctx.text("invalid token", 403);
-  }
-  // default is used here get the default registrar
-  const allDataChannels = await ctx.env.DATA_CHANNEL_REGISTRAR.list(
-    "default",
-    token.data
-  );
+    if (!token.success) {
+        console.error(token.error);
+        return ctx.json(
+            {
+                error: 'invalid token',
+            },
+            403
+        );
+    }
+    if (!token.data.catalystToken) console.error('catalyst token is undefined when building gateway');
+    const claims = ctx.get('claims');
+    if (!claims) {
+        console.error('no claims found');
+        return ctx.json(
+            {
+                error: 'no claims found',
+            },
+            403
+        );
+    }
+    const dataChannelsSingleUseTokens = await generateSingleUseCatalystTokens(claims, token.data.catalystToken!, ctx);
+    if (!dataChannelsSingleUseTokens.success) {
+        return ctx.json(
+            {
+                error: 'not resources found',
+            },
+            403
+        );
+    }
+    const yoga = createYoga({
+        schema: await makeGatewaySchema(dataChannelsSingleUseTokens.data),
+    });
 
-  if (!allDataChannels.success) {
-    console.error(allDataChannels.error);
-    return ctx.text("no resources found", 403);
-  }
-  const dataChannels = DataChannel.safeParse(allDataChannels.data).success
-    ? [DataChannel.parse(allDataChannels.data)]
-    : DataChannel.array().parse(allDataChannels.data);
-  console.log({ allDataChannels });
-  if (!token.data.catalystToken)
-    console.error("catalyst token is undefined when building gateway");
-  const yoga = createYoga({
-    schema: await makeGatewaySchema(dataChannels, token.data.catalystToken!),
-  });
-
-  return yoga(ctx.req.raw, ctx.env);
+    // @ts-expect-error: for some reason TS is not happy with the yoga function receiving the raw request
+    // ignore for now, fix later
+    return yoga(ctx.req.raw, ctx.env);
 });
 
 export default app;

--- a/apps/data_channel_gateway/src/tokenGenerators.ts
+++ b/apps/data_channel_gateway/src/tokenGenerators.ts
@@ -1,0 +1,38 @@
+import { Context } from 'hono';
+import { Variables } from './types';
+
+import { Env } from './env';
+
+export async function generateSingleUseCatalystTokens(
+    claims: string[],
+    catalystToken: string,
+    ctx: Context<{ Bindings: Env; Variables: Variables }>
+): Promise<{ success: boolean; data: { endpoint: string; singleUseToken: string }[] }> {
+    // for each data channel create a single use JWT
+    const singleUseTokens: { endpoint: string; singleUseToken: string }[] = [];
+
+    for (const dataChannelId of claims) {
+        console.log(dataChannelId, 'dataChannelId');
+        const singleUseToken = await ctx.env.AUTHX_TOKEN_API.signSingleUseJWT(
+            dataChannelId,
+            { catalystToken },
+            'default'
+        );
+        console.log(singleUseToken, 'sTuses');
+        if (!singleUseToken.success) {
+            return {
+                success: false,
+                data: [],
+            };
+        }
+        singleUseTokens.push({
+            endpoint: dataChannelId,
+            singleUseToken: singleUseToken.token,
+        });
+    }
+
+    return {
+        success: true,
+        data: singleUseTokens,
+    };
+}

--- a/apps/data_channel_gateway/src/types.ts
+++ b/apps/data_channel_gateway/src/types.ts
@@ -1,0 +1,9 @@
+export type Variables = {
+    claims: string[];
+    'catalyst-token': string;
+};
+
+export type SingleUseToken = {
+    endpoint: string; // data channel endpoint URL
+    singleUseToken: string; // single use JWT for the data channel CLAIM
+};

--- a/apps/data_channel_gateway/tests/jwt-registry.spec.ts
+++ b/apps/data_channel_gateway/tests/jwt-registry.spec.ts
@@ -1,23 +1,19 @@
-// add to git
-
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { env } from 'cloudflare:test';
-import JWTRegistry from '@catalyst/issued-jwt-registry/src';
-describe("jwt registry integration tests", () => {
-  it("can add items to the revocation list", async () =>{
-    console.log(env)
-    const jwtDoID = env.JWT_REGISTRY_DO.idFromName('default');
-    const jwtRegistryStub = env.JWT_REGISTRY_DO.get(jwtDoID);
-    
-    await jwtRegistryStub.create({
-        name: "testJWT",
-        description: "test jwt",
-        status: "active",
-        expiry: new Date(Date.now() + 1000),
-        claims: ["testClaim"],
-        organization: "testorg"
-    })
-  })
-  
-})
 
+describe('jwt registry integration tests', () => {
+    it('can add items to the revocation list', async () => {
+        console.log(env);
+        const jwtDoID = env.JWT_REGISTRY_DO.idFromName('default');
+        const jwtRegistryStub = env.JWT_REGISTRY_DO.get(jwtDoID);
+
+        await jwtRegistryStub.create({
+            name: 'testJWT',
+            description: 'test jwt',
+            status: 'active',
+            expiry: new Date(Date.now() + 1000),
+            claims: ['testClaim'],
+            organization: 'testorg',
+        });
+    });
+});

--- a/apps/data_channel_gateway/vitest.config.ts
+++ b/apps/data_channel_gateway/vitest.config.ts
@@ -44,6 +44,9 @@ export default defineWorkersConfig({
                         },
                     },
                     unsafeEphemeralDurableObjects: true,
+                    serviceBindings: {
+                        AUTHZED: 'authx_authzed_api',
+                    },
                     workers: [
                         {
                             name: 'authx_token_api',
@@ -55,6 +58,9 @@ export default defineWorkersConfig({
                             unsafeEphemeralDurableObjects: true,
                             durableObjects: {
                                 KEY_PROVIDER: 'JWTKeyProvider',
+                            },
+                            serviceBindings: {
+                                DATA_CHANNEL_REGISTRAR: 'data_channel_registrar',
                             },
                         },
                         {
@@ -100,9 +106,6 @@ export default defineWorkersConfig({
                             },
                         },
                     ],
-                    serviceBindings: {
-                        AUTHZED: 'authx_authzed_api',
-                    },
                 },
             },
         },

--- a/apps/data_channel_gateway/wrangler.jsonc
+++ b/apps/data_channel_gateway/wrangler.jsonc
@@ -1,67 +1,54 @@
 {
-  "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "data_channel_gateway",
-  "compatibility_date": "2025-04-01",
-  "compatibility_flags": ["nodejs_compat"],
-  "main": "./src/index.ts",
-  "preview_urls": false,
-  "workers_dev": false,
-  "minify": true,
-  "keep_vars": true,
-  "send_metrics": false,
-  "observability": {
-    "enabled": true
-  },
-  "services": [
-    { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar" },
-    { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api" },
-    { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api" },
-    { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry" }
-  ],
-  "env": {
-    "preview": {
-      "services": [
-        { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-preview" },
-        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-preview" },
-        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-preview" },
-        { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-preview" }
-      ],
-      "routes": [
-        { "pattern": "gateway.catalyst.devintelops.io", "custom_domain": true }
-      ]
+    "$schema": "./node_modules/wrangler/config-schema.json",
+    "name": "data_channel_gateway",
+    "compatibility_date": "2025-04-01",
+    "compatibility_flags": ["nodejs_compat"],
+    "main": "./src/index.ts",
+    "preview_urls": false,
+    "workers_dev": false,
+    "minify": true,
+    "keep_vars": true,
+    "send_metrics": false,
+    "observability": {
+        "enabled": true,
     },
-    "staging": {
-      "services": [
-        { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-staging" },
-        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-staging" },
-        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-staging" },
-        { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-staging" }
-      ],
-      "routes": [
-        { "pattern": "gateway.catalyst.devintelops.io", "custom_domain": true }
-      ]
+    "services": [
+        { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar" },
+        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api" },
+        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api" },
+    ],
+    "env": {
+        "preview": {
+            "services": [
+                { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-preview" },
+                { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-preview" },
+                { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-preview" },
+            ],
+            "routes": [{ "pattern": "gateway.catalyst.devintelops.io", "custom_domain": true }],
+        },
+        "staging": {
+            "services": [
+                { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-staging" },
+                { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-staging" },
+                { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-staging" },
+            ],
+            "routes": [{ "pattern": "gateway.catalyst.devintelops.io", "custom_domain": true }],
+        },
+        "demo": {
+            "services": [
+                { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-demo" },
+                { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-demo" },
+                { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-demo" },
+            ],
+            "routes": [{ "pattern": "gateway.catalyst.demointelops.io", "custom_domain": true }],
+        },
+        "production": {
+            "services": [
+                { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-production" },
+                { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-production" },
+                { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-production" },
+            ],
+            "routes": [{ "pattern": "gateway.catalyst.intelops.io", "custom_domain": true }],
+        },
     },
-    "demo": {
-      "services": [
-        { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-demo" },
-        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-demo" },
-        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-demo" },
-        { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-demo" }
-      ],
-      "routes": [
-        { "pattern": "gateway.catalyst.demointelops.io", "custom_domain": true }
-      ]
-    },
-    "production": {
-      "services": [
-        { "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-production" },
-        { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-production" },
-        { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-production" },
-        { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-production" }
-      ],
-      "routes": [
-        { "pattern": "gateway.catalyst.intelops.io", "custom_domain": true }
-      ]
-    }
-  }
 }

--- a/apps/data_channel_registrar/src/worker.ts
+++ b/apps/data_channel_registrar/src/worker.ts
@@ -43,7 +43,7 @@ export default class RegistrarWorker extends WorkerEntrypoint<Env> {
       parsedUser.data.userId,
     );
     if (!canCreate) {
-      console.log("cannot create: ", parsedUser.data.orgId, parsedUser.data.userId, canCreate);
+      console.log('cannot create: ', parsedUser.data.orgId, parsedUser.data.userId, canCreate);
       return PermissionCheckResponse.parse({
         success: false,
         error:
@@ -97,7 +97,7 @@ export default class RegistrarWorker extends WorkerEntrypoint<Env> {
       if (channel && channel.accessSwitch === false) {
         return PermissionCheckResponse.parse({
           success: false,
-          error: "catalyst cannot access disabled data channels",
+          error: 'catalyst cannot access disabled data channels',
         });
       }
       // validate JWT here

--- a/apps/data_channel_registrar/vitest.config.ts
+++ b/apps/data_channel_registrar/vitest.config.ts
@@ -167,6 +167,23 @@ export default defineWorkersConfig({
               },
               outboundService: handleCloudflareAccessAuthServiceOutbound,
             },
+            {
+              name: 'data_channel_registrar',
+              modules: true,
+              modulesRoot: path.resolve('../data_channel_registrar'),
+              scriptPath: path.resolve('../data_channel_registrar/dist/worker.js'),
+              compatibilityDate: '2025-04-01',
+              compatibilityFlags: ['nodejs_compat'],
+              entrypoint: 'RegistrarWorker',
+              unsafeEphemeralDurableObjects: true,
+              durableObjects: {
+                DO: 'Registrar',
+              },
+              serviceBindings: {
+                AUTHX_TOKEN_API: 'authx_token_api',
+                AUTHZED: 'authx_authzed_api',
+              },
+            },
           ],
         },
       },


### PR DESCRIPTION
### TL;DR

Added single-use JWT functionality to the token API for data channel access, improving security by generating short-lived tokens for each data channel request.

### What changed?

- Added a new `decodeToken` method to the JWT Key Provider to extract payload information
- Implemented `signSingleUseJWT` function in the token API to create short-lived tokens for data channels
- Updated the data channel gateway to use single-use tokens instead of passing the main Catalyst token
- Added the data channel registrar as a dependency to the token API
- Created new helper files in the data channel gateway for token generation
- Fixed type definitions and improved error handling throughout the codebase

### How to test?

1. no unit tests implemented yet. Incomming in next PR

### Why make this change?

This change improves security by implementing the principle of least privilege. Instead of passing the full Catalyst token (which may have broad permissions) to data channels, we now generate short-lived, single-use tokens that are specific to each data channel. This limits the potential damage if a token is compromised and provides better access control granularity.