### PR TITLE
test(authx): add istanbul coverage to authx_authzed_api and authx_token_api

### DIFF
--- a/apps/authx_authzed_api/package.json
+++ b/apps/authx_authzed_api/package.json
@@ -3,24 +3,24 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
-		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
 		"dev": "wrangler dev --port 5050",
 		"test": "vitest",
 		"test:workspace": "vitest run --silent",
+		"test:coverage": "vitest --coverage",
 		"build": "wrangler build"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "catalog:",
-		"@cloudflare/workers-types": "catalog:",
-		"@eslint/js": "catalog:",
-		"typescript": "catalog:",
-		"vitest": "catalog:",
-		"wrangler": "catalog:"
+		"@cloudflare/vitest-pool-workers": "^0.8.23",
+		"@cloudflare/workers-types": "^4.20250430.0",
+		"@eslint/js": "^9.25.1",
+		"@vitest/coverage-istanbul": "^3.1.3",
+		"typescript": "^5.5.4",
+		"vitest": "^3.1.3",
+		"wrangler": "^4.14.0"
 	},
 	"dependencies": {
 		"@catalyst/schema_zod": "workspace:^",
-		"tslog": "catalog:",
+		"tslog": "^4.9.3",
 		"zod": "^3.22.4"
 	}
 }

--- a/apps/authx_authzed_api/vitest.config.ts
+++ b/apps/authx_authzed_api/vitest.config.ts
@@ -21,5 +21,23 @@ export default defineWorkersConfig({
 				},
 			},
 		},
+		coverage: {
+			provider: 'istanbul',
+			reporter: ['text', 'html', 'json-summary'],
+			reportsDirectory: './coverage',
+			include: ['src/**/*.{ts,js}'],
+			exclude: [
+				'**/node_modules/**',
+				'**/dist/**',
+				'**/test/**',
+				'**/tests/**',
+				'**/*.{test,spec}.?(c|m)[jt]s?(x)',
+				'**/wrangler.jsonc',
+				'**/vitest.config.*',
+				'**/.wrangler/**',
+				'**/env.d.ts',
+				'**/global-setup.ts',
+			],
+		},
 	},
 });

--- a/apps/authx_token_api/package.json
+++ b/apps/authx_token_api/package.json
@@ -9,21 +9,23 @@
 		"dev": "wrangler dev --port 5051",
 		"test": "vitest",
 		"test:workspace": "vitest run --silent",
+		"test:coverage": "vitest --coverage",
 		"build": "wrangler build",
 		"postinstall": "pnpm build"
 	},
 	"devDependencies": {
 		"@catalyst/schema_zod": "workspace:*",
-		"@cloudflare/vitest-pool-workers": "catalog:",
-		"@cloudflare/workers-types": "catalog:",
-		"@eslint/js": "catalog:",
-		"@types/uuid": "catalog:",
-		"base64url": "catalog:",
+		"@cloudflare/vitest-pool-workers": "^0.8.23",
+		"@cloudflare/workers-types": "^4.20250430.0",
+		"@eslint/js": "^9.25.1",
+		"@types/uuid": "^9.0.8",
+		"@vitest/coverage-istanbul": "^3.1.3",
+		"base64url": "^3.0.1",
 		"bun": "^1.1.7",
-		"jose": "^5.2.4",
-		"typescript": "catalog:",
-		"uuid": "catalog:",
-		"vitest": "catalog:",
-		"wrangler": "catalog:"
+		"jose": "^5.10.0",
+		"typescript": "^5.8.3",
+		"uuid": "^9.0.1",
+		"vitest": "^3.1.3",
+		"wrangler": "^4.14.0"
 	}
 }

--- a/apps/authx_token_api/vitest.config.ts
+++ b/apps/authx_token_api/vitest.config.ts
@@ -1,22 +1,23 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 import path from 'path';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const validUsers: Record<string, any> = {
 	'admin-cf-token': {
 		email: 'email@example.com',
 		custom: {
 			'urn:zitadel:iam:org:project:roles': {
 				'data-custodian': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 				'org-admin': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 				'org-user': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 				'platform-admin': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 			},
 		},
@@ -26,10 +27,10 @@ const validUsers: Record<string, any> = {
 		custom: {
 			'urn:zitadel:iam:org:project:roles': {
 				'data-custodian': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 				'org-user': {
-					'YES': 'auth.provider.io',
+					YES: 'auth.provider.io',
 				},
 			},
 		},
@@ -128,6 +129,25 @@ export default defineWorkersConfig({
 					],
 				},
 			},
+		},
+		coverage: {
+			provider: 'istanbul',
+			reporter: ['text', 'html', 'json-summary'],
+			reportsDirectory: './coverage',
+			include: ['src/**/*.{ts,js}'], // Adjust if your source files are elsewhere
+			exclude: [
+				// Common exclusions
+				'**/node_modules/**',
+				'**/dist/**',
+				'**/test/**',
+				'**/tests/**',
+				'**/*.{test,spec}.?(c|m)[jt]s?(x)', // Exclude test file patterns
+				'**/wrangler.jsonc',
+				'**/vitest.config.*',
+				'**/.wrangler/**',
+				'**/env.d.ts',
+				'**/global-setup.ts',
+			],
 		},
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@chakra-ui/react':
       specifier: ^2.8.2
       version: 2.10.7
-    '@cloudflare/vitest-pool-workers':
-      specifier: ^0.8.22
-      version: 0.8.23
     '@cloudflare/workers-types':
       specifier: ^4.20250414.0
       version: 4.20250430.0
@@ -54,15 +51,9 @@ catalogs:
     '@types/mocha':
       specifier: ^10
       version: 10.0.10
-    '@types/uuid':
-      specifier: ^9.0.8
-      version: 9.0.8
     '@urql/core':
       specifier: ^4.3.0
       version: 4.3.0
-    base64url:
-      specifier: ^3.0.1
-      version: 3.0.1
     chai:
       specifier: ^4
       version: 4.5.0
@@ -141,12 +132,6 @@ catalogs:
     unstorage:
       specifier: ^1.10.2
       version: 1.16.0
-    uuid:
-      specifier: ^9.0.1
-      version: 9.0.1
-    vitest:
-      specifier: ~3.0.7
-      version: 3.0.9
     wrangler:
       specifier: ^4.13.2
       version: 4.13.2
@@ -210,30 +195,33 @@ importers:
         specifier: workspace:^
         version: link:../../packages/schema_zod
       tslog:
-        specifier: 'catalog:'
+        specifier: ^4.9.3
         version: 4.9.3
       zod:
         specifier: ^3.22.4
         version: 3.24.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
-        specifier: 'catalog:'
-        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
+        specifier: ^0.8.23
+        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       '@cloudflare/workers-types':
-        specifier: 'catalog:'
+        specifier: ^4.20250430.0
         version: 4.20250430.0
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: ^9.25.1
         version: 9.25.1
+      '@vitest/coverage-istanbul':
+        specifier: ^3.1.3
+        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       typescript:
-        specifier: 'catalog:'
+        specifier: ^5.5.4
         version: 5.8.3
       vitest:
-        specifier: 'catalog:'
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.1.3
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
       wrangler:
-        specifier: 'catalog:'
-        version: 4.13.2(@cloudflare/workers-types@4.20250430.0)
+        specifier: ^4.14.0
+        version: 4.14.0(@cloudflare/workers-types@4.20250430.0)
 
   apps/authx_token_api:
     devDependencies:
@@ -241,38 +229,41 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema_zod
       '@cloudflare/vitest-pool-workers':
-        specifier: 'catalog:'
-        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
+        specifier: ^0.8.23
+        version: 0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       '@cloudflare/workers-types':
-        specifier: 'catalog:'
+        specifier: ^4.20250430.0
         version: 4.20250430.0
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: ^9.25.1
         version: 9.25.1
       '@types/uuid':
-        specifier: 'catalog:'
+        specifier: ^9.0.8
         version: 9.0.8
+      '@vitest/coverage-istanbul':
+        specifier: ^3.1.3
+        version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
       base64url:
-        specifier: 'catalog:'
+        specifier: ^3.0.1
         version: 3.0.1
       bun:
         specifier: ^1.1.7
         version: 1.2.11
       jose:
-        specifier: ^5.2.4
+        specifier: ^5.10.0
         version: 5.10.0
       typescript:
-        specifier: 'catalog:'
+        specifier: ^5.8.3
         version: 5.8.3
       uuid:
-        specifier: 'catalog:'
+        specifier: ^9.0.1
         version: 9.0.1
       vitest:
-        specifier: 'catalog:'
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
+        specifier: ^3.1.3
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
       wrangler:
-        specifier: 'catalog:'
-        version: 4.13.2(@cloudflare/workers-types@4.20250430.0)
+        specifier: ^4.14.0
+        version: 4.14.0(@cloudflare/workers-types@4.20250430.0)
 
   apps/catalyst-ui-worker:
     dependencies:
@@ -11449,23 +11440,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))':
-    dependencies:
-      '@vitest/runner': 3.1.3
-      '@vitest/snapshot': 3.1.3
-      birpc: 0.2.14
-      cjs-module-lexer: 1.4.3
-      devalue: 4.3.3
-      miniflare: 4.20250428.0
-      semver: 7.7.1
-      vitest: 3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
-      wrangler: 4.14.0(@cloudflare/workers-types@4.20250430.0)
-      zod: 3.24.3
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - bufferutil
-      - utf-8-validate
-
   '@cloudflare/vitest-pool-workers@0.8.23(@cloudflare/workers-types@4.20250430.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
       '@vitest/runner': 3.1.3
@@ -14560,14 +14534,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.4(@types/node@20.17.32)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
-
-  '@vitest/mocker@3.0.9(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))':
-    dependencies:
-      '@vitest/spy': 3.0.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
 
   '@vitest/mocker@3.1.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
@@ -20244,27 +20210,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.9(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.1.3(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       cac: 6.7.14
@@ -20343,45 +20288,6 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.17.32
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1):
-    dependencies:
-      '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1))
-      '@vitest/pretty-format': 3.1.2
-      '@vitest/runner': 3.0.9
-      '@vitest/snapshot': 3.0.9
-      '@vitest/spy': 3.0.9
-      '@vitest/utils': 3.0.9
-      chai: 5.2.0
-      debug: 4.4.0(supports-color@8.1.1)
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 2.0.0
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
-      vite-node: 3.0.9(@types/node@22.15.3)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.7.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 22.15.3
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
### TL;DR

Added code coverage configuration and updated package dependencies to use explicit versions instead of catalog references.

### What changed?

- Added test coverage configuration with Istanbul provider to both `authx_authzed_api` and `authx_token_api` projects
- Added `test:coverage` script to both projects' package.json files
- Updated all dependencies to use explicit version numbers instead of `catalog:` references
- Removed deployment scripts from `authx_authzed_api`
- Fixed code formatting in the `validUsers` object in `authx_token_api/vitest.config.ts`

### How to test?

1. Run `pnpm test:coverage` in either project directory to generate coverage reports
2. Verify that coverage reports are generated in the `./coverage` directory
3. Check that the HTML, text, and JSON summary reports are available

### Why make this change?

This change improves the development workflow by:
1. Adding code coverage reporting to help identify untested code paths
2. Making dependency versions explicit for better reproducibility and version control
3. Standardizing the test configuration across projects
4. Removing unused deployment scripts to simplify the codebase