### PR TITLE
feat: add multi-pair validation for data channel access

### DIFF
--- a/apps/data_channel_gateway/tests/validate-tokens.spec.ts
+++ b/apps/data_channel_gateway/tests/validate-tokens.spec.ts
@@ -1,0 +1,247 @@
+import { DataChannel } from '@catalyst/schema_zod';
+import { env, SELF } from 'cloudflare:test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TEST_ORG, TEST_USER, generateCatalystToken } from './testUtils';
+import type { ValidateTokenResponse } from '../src/index';
+
+const DUMMY_DATA_CHANNELS: DataChannel[] = [
+    {
+        id: 'airplanes1',
+        name: 'airplanes1',
+        endpoint: 'http://localhost:8080/graphql',
+        accessSwitch: true,
+        description: 'Test airplane data channel 1',
+        creatorOrganization: TEST_ORG,
+    },
+    {
+        id: 'airplanes2',
+        name: 'airplanes2',
+        endpoint: 'http://localhost:8081/graphql',
+        accessSwitch: true,
+        description: 'Test airplane data channel 2',
+        creatorOrganization: TEST_ORG,
+    },
+];
+
+const setup = async () => {
+    for (const dataChannel of DUMMY_DATA_CHANNELS) {
+        // Add proper permissions for the test user
+        await env.AUTHX_AUTHZED_API.addOrgToDataChannel(dataChannel.id, TEST_ORG);
+        await env.AUTHX_AUTHZED_API.addDataChannelToOrg(TEST_ORG, dataChannel.id);
+        await env.AUTHX_AUTHZED_API.addUserToOrg(TEST_ORG, TEST_USER);
+
+        // Update the data channel using the Durable Object
+        const id = env.DATA_CHANNEL_REGISTRAR_DO.idFromName('default');
+        const stub = env.DATA_CHANNEL_REGISTRAR_DO.get(id);
+        await stub.update(dataChannel);
+    }
+};
+
+const teardown = async () => {
+    // Clean up the airplane data channel using the Durable Object
+    const id = env.DATA_CHANNEL_REGISTRAR_DO.idFromName('default');
+    const stub = env.DATA_CHANNEL_REGISTRAR_DO.get(id);
+    await stub.delete('airplanes1');
+    await stub.delete('airplanes2');
+
+    // Clean up permissions
+    await env.AUTHX_AUTHZED_API.deleteOrgInDataChannel('airplanes1', TEST_ORG);
+    await env.AUTHX_AUTHZED_API.deleteOrgInDataChannel('airplanes2', TEST_ORG);
+    await env.AUTHX_AUTHZED_API.deleteDataChannelInOrg(TEST_ORG, 'airplanes1');
+    await env.AUTHX_AUTHZED_API.deleteDataChannelInOrg(TEST_ORG, 'airplanes2');
+    await env.AUTHX_AUTHZED_API.deleteUserFromOrg(TEST_ORG, TEST_USER);
+};
+
+describe('validate endpoint tests', () => {
+    beforeEach(async () => {
+        await setup();
+    });
+
+    afterEach(async () => {
+        await teardown();
+    });
+
+    it('should return 400 for non-array request body', async () => {
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ invalid: 'request' }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = await response.json();
+        expect(data).toEqual({ error: 'request body must be an array' });
+    });
+
+    it('should validate a single valid claim', async (testContext) => {
+        const token = await generateCatalystToken(TEST_ORG, ['airplanes1'], testContext);
+
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+                {
+                    claimId: 'airplanes1',
+                    catalystToken: token,
+                },
+            ]),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ValidateTokenResponse[];
+        expect(data).toEqual([
+            {
+                claimId: 'airplanes1',
+                catalystToken: token,
+                valid: true,
+                error: '',
+            },
+        ]);
+    });
+
+    it('should validate multiple claims', async (testContext) => {
+        const token = await generateCatalystToken(TEST_ORG, ['airplanes1', 'airplanes2'], testContext);
+
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+                {
+                    claimId: 'airplanes1',
+                    catalystToken: token,
+                },
+                {
+                    claimId: 'airplanes2',
+                    catalystToken: token,
+                },
+            ]),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ValidateTokenResponse[];
+        expect(data).toEqual([
+            {
+                claimId: 'airplanes1',
+                catalystToken: token,
+                valid: true,
+                error: '',
+            },
+            {
+                claimId: 'airplanes2',
+                catalystToken: token,
+                valid: true,
+                error: '',
+            },
+        ]);
+    });
+
+    it('should handle invalid tokens', async () => {
+        const invalidToken = 'invalid-token';
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+                {
+                    claimId: 'airplanes1',
+                    catalystToken: invalidToken,
+                },
+            ]),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ValidateTokenResponse[];
+        expect(data).toEqual([
+            {
+                claimId: 'airplanes1',
+                catalystToken: invalidToken,
+                valid: false,
+                error: 'no data channels found for token',
+            },
+        ]);
+    });
+
+    it('should handle non-existent claim IDs', async (testContext) => {
+        const token = await generateCatalystToken(TEST_ORG, ['airplanes1'], testContext);
+
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+                {
+                    claimId: 'non-existent-channel',
+                    catalystToken: token,
+                },
+            ]),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ValidateTokenResponse[];
+        expect(data).toEqual([
+            {
+                claimId: 'non-existent-channel',
+                catalystToken: token,
+                valid: false,
+                error: "data channel 'non-existent-channel' not found in available channels",
+            },
+        ]);
+    });
+
+    it('should handle mixed valid and invalid claims', async (testContext) => {
+        const token = await generateCatalystToken(TEST_ORG, ['airplanes1'], testContext);
+        const invalidToken = 'invalid-token';
+
+        const response = await SELF.fetch('https://data-channel-gateway/validate-tokens', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+                {
+                    claimId: 'airplanes1',
+                    catalystToken: token,
+                },
+                {
+                    claimId: 'non-existent-channel',
+                    catalystToken: token,
+                },
+                {
+                    claimId: 'airplanes2',
+                    catalystToken: invalidToken,
+                },
+            ]),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as ValidateTokenResponse[];
+        expect(data).toEqual([
+            {
+                claimId: 'airplanes1',
+                catalystToken: token,
+                valid: true,
+                error: '',
+            },
+            {
+                claimId: 'non-existent-channel',
+                catalystToken: token,
+                valid: false,
+                error: "data channel 'non-existent-channel' not found in available channels",
+            },
+            {
+                claimId: 'airplanes2',
+                catalystToken: invalidToken,
+                valid: false,
+                error: 'no data channels found for token',
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
~~NOTE: this can not be merged until https://github.com/orbisoperations/catalyst-proxy-service/issues/22 is done.~~
can now merge this in, since we have:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/y7QrtfR2ARL8DWxW4aKY/0c5e7165-e1d4-439e-8931-06aeaa6d7276.png)

---------------------
feat: add multi-pair validation for data channel access

moving changes to data channel gateway

feat: add bulk token validation endpoint and tests

```
ihammerstrom@Ians-MacBook-Pro catalyst % cd /Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/data_channel_gateway && npm test tests/validate-tokens.spec.ts       cd /Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/data_channel_gateway && npm test tests/validate-tokens.spec.ts

> test
> vitest tests/validate-tokens.spec.ts

2025-05-29 10:46:27.329 INFO    /node_modules/.vite-temp/vitest.config.ts.timestamp-1748515587325-187b57ab61055.mjs:10      Using built services from other workspaces within @catalyst
2025-05-29 10:46:27.331 INFO    /node_modules/.vite-temp/vitest.config.ts.timestamp-1748515587325-187b57ab61055.mjs:11      {
  authxServicePath: '/Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js',
  dataChannelRegistrarPath: '/Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/data_channel_registrar/dist/worker.js',
  authzedServicePath: '/Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_authzed_api/dist/index.js',
  jwtRegistryPath: '/Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/issued-jwt-registry/dist/index.js'
}
2025-05-29 10:46:27.331 INFO    /node_modules/.vite-temp/vitest.config.ts.timestamp-1748515587325-187b57ab61055.mjs:17      Setting up vite tests for the gateway...

 DEV  v3.1.3 /Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/data_channel_gateway

Building dependencies
Compiled ../authx_token_api: 379.935ms
Compiled ../authx_authzed_api: 374.62ms
Compiled ../data_channel_registrar: 381.201ms
Compiled ../issued-jwt-registry: 383.285ms
Starting authzed podman container
Successfully built dependencies
Authzed podman container started successfully
[vpw:inf] Starting single runtime for vitest.config.ts...
stdout | tests/validate-tokens.spec.ts > validate endpoint tests > should validate a single valid claim
{
  test: 'should validate a single valid claim',
  signedTokenForTest: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJjYXRhbHlzdDpzeXN0ZW06and0OmxhdGVzdCIsInN1YiI6InRlc3Rfb3JnL3Rlc3RfdXNlckBtYWlsLmNvbSIsImNsYWltcyI6WyJhaXJwbGFuZXMxIl0sImF1ZCI6ImNhdGFseXN0OnN5c3RlbTpkYXRhY2hhbm5lbHMiLCJqdGkiOiJmNzUxNzk5ZC1kOTZiLTQ5MTYtODg0Yy1hMWVjYTg0YjZlNWIiLCJuYmYiOjE3NDg1MTU1ODgsImlhdCI6MTc0ODUxNTU4OSwiZXhwIjoxNzQ4NTE2MTg5fQ.E_nQZC4UtLOvtaAzC2RRS8U2IACb34Whe1jKUrKrDccU9pTbIDsSUokR7YMb2hvibXExmm7s9_DYSyH1FSPlAA'
}

{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: 'f751799d-d96b-4916-884c-a1eca84b6e5b'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: 'f751799d-d96b-4916-884c-a1eca84b6e5b'
  }
}
data channel permission check asserts local(true) and partner(false) paths
stdout | tests/validate-tokens.spec.ts > validate endpoint tests > should validate multiple claims
{
  test: 'should validate multiple claims',
  signedTokenForTest: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJjYXRhbHlzdDpzeXN0ZW06and0OmxhdGVzdCIsInN1YiI6InRlc3Rfb3JnL3Rlc3RfdXNlckBtYWlsLmNvbSIsImNsYWltcyI6WyJhaXJwbGFuZXMxIiwiYWlycGxhbmVzMiJdLCJhdWQiOiJjYXRhbHlzdDpzeXN0ZW06ZGF0YWNoYW5uZWxzIiwianRpIjoiYjI5M2E0MWMtMTE1MS00MDE1LWE5ZDUtMDE2MjliNjk5OGNjIiwibmJmIjoxNzQ4NTE1NTg4LCJpYXQiOjE3NDg1MTU1ODksImV4cCI6MTc0ODUxNjE4OX0.rJTzr2sqcOIYY9WXNt2mHXpu5fW845iD5FAGQkgZ4AhrgvWoAT2Ab3JUnEiybo__WvsCXJ9vf7aFuruxCIc4Dg'
}

{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1', 'airplanes2' ],
    jwtId: 'b293a41c-1151-4015-a9d5-01629b6998cc'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1', 'airplanes2' ],
    jwtId: 'b293a41c-1151-4015-a9d5-01629b6998cc'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1', 'airplanes2' ],
    jwtId: 'b293a41c-1151-4015-a9d5-01629b6998cc'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1', 'airplanes2' ],
    jwtId: 'b293a41c-1151-4015-a9d5-01629b6998cc'
  }
}
data channel permission check asserts local(true) and partner(false) paths
data channel permission check asserts local(true) and partner(false) paths
data channel permission check asserts local(true) and partner(false) paths
data channel permission check asserts local(true) and partner(false) paths
error validating token JWSInvalid: Invalid Compact JWS
    at compactVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:7953)
    at jwtVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:11133)
    at Lr.validateToken (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:24102) {
  code: 'ERR_JWS_INVALID'
}
error validating token JWSInvalid: Invalid Compact JWS
    at compactVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:7953)
    at jwtVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:11133)
    at Lr.validateToken (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:24102) {
  code: 'ERR_JWS_INVALID'
}
stdout | tests/validate-tokens.spec.ts > validate endpoint tests > should handle non-existent claim IDs
{
  test: 'should handle non-existent claim IDs',
  signedTokenForTest: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJjYXRhbHlzdDpzeXN0ZW06and0OmxhdGVzdCIsInN1YiI6InRlc3Rfb3JnL3Rlc3RfdXNlckBtYWlsLmNvbSIsImNsYWltcyI6WyJhaXJwbGFuZXMxIl0sImF1ZCI6ImNhdGFseXN0OnN5c3RlbTpkYXRhY2hhbm5lbHMiLCJqdGkiOiI0OWE2MjFhMi1iY2U0LTQ5NGQtYmFkZC0wZmZhYjEwODliMGYiLCJuYmYiOjE3NDg1MTU1ODgsImlhdCI6MTc0ODUxNTU4OSwiZXhwIjoxNzQ4NTE2MTg5fQ.dc2w_DrwLFcSFbRkEFxiOkL2n2yPVcNAYWH3gPcZah6nsKgLKyA3CLNrOyU8SPzDUvYcGk0mgN8QgdH4hKqYDQ'
}

{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '49a621a2-bce4-494d-badd-0ffab1089b0f'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '49a621a2-bce4-494d-badd-0ffab1089b0f'
  }
}
data channel permission check asserts local(true) and partner(false) paths
stdout | tests/validate-tokens.spec.ts > validate endpoint tests > should handle mixed valid and invalid claims
{
  test: 'should handle mixed valid and invalid claims',
  signedTokenForTest: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJjYXRhbHlzdDpzeXN0ZW06and0OmxhdGVzdCIsInN1YiI6InRlc3Rfb3JnL3Rlc3RfdXNlckBtYWlsLmNvbSIsImNsYWltcyI6WyJhaXJwbGFuZXMxIl0sImF1ZCI6ImNhdGFseXN0OnN5c3RlbTpkYXRhY2hhbm5lbHMiLCJqdGkiOiI3YmIyODRlMy0xZWMxLTQ4MDUtOTY3My05ZTQxZDAyY2M5OTAiLCJuYmYiOjE3NDg1MTU1ODgsImlhdCI6MTc0ODUxNTU4OSwiZXhwIjoxNzQ4NTE2MTg5fQ.XnrCfgZpr5FzdFNiJA_f412orO78wBUEPUbqVkQDJfGV5LGnP2yuwo6w7bImb-c6r7d8ItAseM8F002WPjJuDw'
}

{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '7bb284e3-1ec1-4805-9673-9e41d02cc990'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '7bb284e3-1ec1-4805-9673-9e41d02cc990'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '7bb284e3-1ec1-4805-9673-9e41d02cc990'
  }
}
{
  resp: {
    valid: true,
    entity: 'test_org/test_user@mail.com',
    claims: [ 'airplanes1' ],
    jwtId: '7bb284e3-1ec1-4805-9673-9e41d02cc990'
  }
}
error validating token JWSInvalid: Invalid Compact JWS
    at compactVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:7953)
    at jwtVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:11133)
    at Lr.validateToken (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:24102) {
  code: 'ERR_JWS_INVALID'
}
error validating token JWSInvalid: Invalid Compact JWS
    at compactVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:7953)
    at jwtVerify (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:11133)
    at Lr.validateToken (file:///Users/ihammerstrom/Desktop/code/catalyst_and_related/catalyst/apps/authx_token_api/dist/index.js:4:24102) {
  code: 'ERR_JWS_INVALID'
}
data channel permission check asserts local(true) and partner(false) paths
data channel permission check asserts local(true) and partner(false) paths
 ✓ tests/validate-tokens.spec.ts (6 tests) 173ms
   ✓ validate endpoint tests > should return 400 for non-array request body 29ms
   ✓ validate endpoint tests > should validate a single valid claim 33ms
   ✓ validate endpoint tests > should validate multiple claims 39ms
   ✓ validate endpoint tests > should handle invalid tokens 17ms
   ✓ validate endpoint tests > should handle non-existent claim IDs 20ms
   ✓ validate endpoint tests > should handle mixed valid and invalid claims 34ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  18:46:27
   Duration  2.61s (transform 60ms, setup 0ms, collect 345ms, tests 173ms, environment 0ms, prepare 75ms)

 PASS  Waiting for file changes...
       press h to show help, press q to quit
[vpw:dbg] Shutting down runtimes...
ihammerstrom@Ians-MacBook-Pro data_channel_gateway % 
```