### PR TITLE
chore(setup): create standalone authzed start script and removed rm flag

### DIFF
--- a/apps/authx_authzed_api/.dev.vars.example
+++ b/apps/authx_authzed_api/.dev.vars.example
@@ -1,3 +1,3 @@
-AUTHZED_ENDPOINT=http://localhost:8443
+AUTHZED_ENDPOINT=http://localhost:8449
 AUTHZED_KEY=atoken
-AUTHZED_PREFIX=local_catalyst_dev/
+AUTHZED_PREFIX=orbisops_catalyst_dev/

--- a/apps/authx_authzed_api/README.md
+++ b/apps/authx_authzed_api/README.md
@@ -49,7 +49,7 @@ Used by the following services:
    - Local development uses a `.dev.vars` file in this directory. Example:
 
      ```env
-     AUTHZED_ENDPOINT="http://localhost:8443"
+     AUTHZED_ENDPOINT="http://localhost:8449"
      AUTHZED_KEY="atoken"
      AUTHZED_PREFIX="orbisops_catalyst_dev/"
      ```
@@ -61,7 +61,7 @@ Used by the following services:
    - You can run a local AuthZed instance using Podman (or Docker). Example command:
 
      ```sh
-     podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro -p 8443:8443 --detach --name authzed-container authzed/spicedb:latest serve-testing --http-enabled --skip-release-check=true --log-level trace --load-configs ./schema.zaml
+     podman run --rm -v ./apps/authx_authzed_api/schema.zaml:/schema.zaml:ro -p 8449:8443 --detach --name authzed-container authzed/spicedb:latest serve-testing --http-enabled --skip-release-check=true --log-level trace --load-configs ./schema.zaml
      ```
 
      > [!IMPORTANT]

--- a/apps/authx_authzed_api/global-setup.ts
+++ b/apps/authx_authzed_api/global-setup.ts
@@ -13,7 +13,7 @@ export default function () {
 	const podmanCommand = [
 		'podman run --rm',
 		'-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-		'-p 8443:8443',
+		'-p 8449:8443',
 		// '--detach',
 		'--name authzed-container',
 		'authzed/spicedb:latest',
@@ -36,7 +36,7 @@ export default function () {
 			} else {
 				console.info('Authzed podman container started successfully');
 			}
-		}
+		},
 	);
 
 	console.info('Global setup complete');

--- a/apps/authx_authzed_api/test/index.spec.ts
+++ b/apps/authx_authzed_api/test/index.spec.ts
@@ -1,26 +1,10 @@
 // test/index.spec.ts
 
 // RUN THIS TO GET IT WORKING
-// podman run -v "$(pwd)"/schema.zaml:/schema.zaml:ro  -p 8443:8443 authzed/spicedb serve-testing --http-enabled --skip-release-check=true --log-level debug --load-configs /schema.zaml
+// podman run -v "$(pwd)"/schema.zaml:/schema.zaml:ro  -p 8449:8443 authzed/spicedb serve-testing --http-enabled --skip-release-check=true --log-level debug --load-configs /schema.zaml
 
 import { SELF, env } from 'cloudflare:test';
 import { describe, expect, it } from 'vitest';
-
-const generateUsers = (count: number = 1) => {
-	const users = [];
-	for (let i = 0; i < count; i++) {
-		users.push(`test-user-${i}`);
-	}
-	return users;
-};
-
-const generateOrgs = (count: number = 1) => {
-	const orgs = [];
-	for (let i = 0; i < count; i++) {
-		orgs.push(`test-org-${i}`);
-	}
-	return orgs;
-};
 
 describe('Authzed Integration via TRPC', () => {
 	it('should have the env vars defined', async () => {

--- a/apps/authx_authzed_api/vitest.config.ts
+++ b/apps/authx_authzed_api/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineWorkersConfig({
 				miniflare: {
 					compatibilityFlags: ['nodejs_compat'],
 					bindings: {
-						AUTHZED_ENDPOINT: 'http://localhost:8443',
+						AUTHZED_ENDPOINT: 'http://localhost:8449',
 						AUTHZED_KEY: 'atoken',
 						AUTHZED_PREFIX: 'orbisops_catalyst_dev/',
 					},

--- a/apps/authx_token_api/global-setup.ts
+++ b/apps/authx_token_api/global-setup.ts
@@ -31,7 +31,7 @@ export default function () {
 	const podmanCommand = [
 		'podman run --rm',
 		'-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-		'-p 8443:8443',
+		'-p 8449:8443',
 		'-d',
 		'--name authzed-container',
 		'authzed/spicedb:latest',

--- a/apps/authx_token_api/vitest.config.ts
+++ b/apps/authx_token_api/vitest.config.ts
@@ -70,7 +70,7 @@ export default defineWorkersConfig({
 							compatibilityFlags: ['nodejs_compat'],
 							entrypoint: 'AuthzedWorker',
 							bindings: {
-								AUTHZED_ENDPOINT: 'http://localhost:8443',
+								AUTHZED_ENDPOINT: 'http://localhost:8449',
 								AUTHZED_KEY: 'atoken',
 								AUTHZED_PREFIX: 'orbisops_catalyst_dev/',
 							},

--- a/apps/data_channel_gateway/global-setup.ts
+++ b/apps/data_channel_gateway/global-setup.ts
@@ -17,7 +17,7 @@ export default function () {
 
     // compile dependencies
     for (const dependency of dependencies) {
-        let label = `Compiled ${dependency}`;
+        const label = `Compiled ${dependency}`;
         console.time(label);
         childProcess.execSync('pnpm build', {
             cwd: path.join(dependency),
@@ -25,38 +25,38 @@ export default function () {
         console.timeEnd(label);
     }
 
-	console.info('Starting authzed podman container');
+    console.info('Starting authzed podman container');
 
-	// current when executing this file is apps/
-	// see execSync command below
-	const podmanCommand = [
-		'podman run --rm',
-		'-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-		'-p 8443:8443',
-		// '--detach',
-		'--name authzed-container',
-		'authzed/spicedb:latest',
-		'serve-testing',
-		'--http-enabled',
-		'--skip-release-check=true',
-		'--log-level debug',
-		'--load-configs ./schema.zaml',
-	].join(' ');
+    // current when executing this file is apps/
+    // see execSync command below
+    const podmanCommand = [
+        'podman run --rm',
+        '-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
+        '-p 8449:8443',
+        // '--detach',
+        '--name authzed-container',
+        'authzed/spicedb:latest',
+        'serve-testing',
+        '--http-enabled',
+        '--skip-release-check=true',
+        '--log-level debug',
+        '--load-configs ./schema.zaml',
+    ].join(' ');
 
-	// turn on podman container for authzed
-	childProcess.exec(
-		podmanCommand,
-		{
-			cwd: path.join(__dirname, '..'),
-		},
-		(err) => {
-			if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
-				console.error('Error starting authzed podman container: Check status with `podman ps`', err);
-			} else {
-				console.info('Authzed podman container started successfully');
-			}
-		}
-	);
+    // turn on podman container for authzed
+    childProcess.exec(
+        podmanCommand,
+        {
+            cwd: path.join(__dirname, '..'),
+        },
+        (err) => {
+            if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
+                console.error('Error starting authzed podman container: Check status with `podman ps`', err);
+            } else {
+                console.info('Authzed podman container started successfully');
+            }
+        }
+    );
 
     console.info('Successfully built dependencies');
 }

--- a/apps/data_channel_gateway/package.json
+++ b/apps/data_channel_gateway/package.json
@@ -2,7 +2,7 @@
     "name": "@catalyst/data_channel_gateway",
     "type": "module",
     "scripts": {
-        "dev": "wrangler dev --port 5052",
+        "dev": "wrangler dev --port 4008",
         "test": "vitest",
         "test:workspace": "vitest run --silent",
         "test:coverage": "vitest --coverage",

--- a/apps/data_channel_gateway/vitest.config.ts
+++ b/apps/data_channel_gateway/vitest.config.ts
@@ -88,7 +88,7 @@ export default defineWorkersConfig({
                             compatibilityDate: '2025-04-01',
                             compatibilityFlags: ['nodejs_compat'],
                             bindings: {
-                                AUTHZED_ENDPOINT: 'http://localhost:8443',
+                                AUTHZED_ENDPOINT: 'http://localhost:8449',
                                 AUTHZED_KEY: 'atoken',
                                 AUTHZED_PREFIX: 'orbisops_catalyst_dev/',
                             },

--- a/apps/data_channel_registrar/global-setup.ts
+++ b/apps/data_channel_registrar/global-setup.ts
@@ -13,7 +13,7 @@ export default function () {
 
   // compile dependencies
   for (const dependency of dependencies) {
-    let label = `Compiled ${dependency}`;
+    const label = `Compiled ${dependency}`;
     console.time(label);
     childProcess.execSync('pnpm build', {
       cwd: path.join(dependency),
@@ -28,7 +28,7 @@ export default function () {
   const podmanCommand = [
     'podman run --rm',
     '-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-    '-p 8443:8443',
+    '-p 8449:8443',
     '-d',
     '--name authzed-container',
     'authzed/spicedb:latest',
@@ -40,16 +40,22 @@ export default function () {
   ].join(' ');
 
   // turn on podman container for authzed
-  childProcess.exec(podmanCommand, {
-    cwd: path.join(__dirname, '..'),
-  }, (err) => {
-    if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
-      logger.error('Error starting authzed podman container: Check status with `podman ps`', err);
-    } else {
-      logger.info('Authzed podman container started successfully');
-    }
-  });
-
+  childProcess.exec(
+    podmanCommand,
+    {
+      cwd: path.join(__dirname, '..'),
+    },
+    err => {
+      if (
+        err &&
+        !err.message.includes('the container name "authzed-container" is already in use')
+      ) {
+        logger.error('Error starting authzed podman container: Check status with `podman ps`', err);
+      } else {
+        logger.info('Authzed podman container started successfully');
+      }
+    },
+  );
 
   logger.info('Global setup complete');
 }

--- a/apps/data_channel_registrar/vitest.config.ts
+++ b/apps/data_channel_registrar/vitest.config.ts
@@ -90,7 +90,7 @@ export default defineWorkersConfig({
               compatibilityFlags: ['nodejs_compat'],
               entrypoint: 'AuthzedWorker',
               bindings: {
-                AUTHZED_ENDPOINT: 'http://localhost:8443',
+                AUTHZED_ENDPOINT: 'http://localhost:8449',
                 AUTHZED_KEY: 'atoken',
                 AUTHZED_PREFIX: 'orbisops_catalyst_dev/',
               },

--- a/apps/organization_matchmaking/global-setup.ts
+++ b/apps/organization_matchmaking/global-setup.ts
@@ -1,56 +1,57 @@
-import childProcess from "node:child_process";
-import path from "node:path";
+import childProcess from 'node:child_process';
+import path from 'node:path';
 
 // Global setup runs inside Node.js, not `workerd`
 export default function () {
-  // Build `api-service`'s dependencies
+	// Build `api-service`'s dependencies
 
-  // list of dependencies to compile
-  const dependencies = [
-    "../authx_authzed_api",
-    "../user-credentials-cache",
-  ];
+	// list of dependencies to compile
+	const dependencies = ['../authx_authzed_api', '../user-credentials-cache'];
 
-  // compile dependencies
-  for (const dependency of dependencies) {
-    let label = `Compiled ${dependency}`;
-    console.time(label);
-    childProcess.execSync("pnpm build", {
-      cwd: path.join(dependency),
-    });
-    console.timeEnd(label);
-  }
+	// compile dependencies
+	for (const dependency of dependencies) {
+		const label = `Compiled ${dependency}`;
+		console.time(label);
+		childProcess.execSync('pnpm build', {
+			cwd: path.join(dependency),
+		});
+		console.timeEnd(label);
+	}
 
-  console.info('Starting authzed podman container');
+	console.info('Starting authzed podman container');
 
-  // current when executing this file is apps/
-  // see execSync command below
-  const podmanCommand = [
-    'podman run --rm',
-    '-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
-    '-p 8443:8443',
-    '--detach',
-    '--name authzed-container',
-    'authzed/spicedb:latest',
-    'serve-testing',
-    '--http-enabled',
-    '--skip-release-check=true',
-    '--log-level debug',
-    '--load-configs ./schema.zaml',
-  ].join(' ');
+	// current when executing this file is apps/
+	// see execSync command below
+	const podmanCommand = [
+		'podman run --rm',
+		'-v ./authx_authzed_api/schema.zaml:/schema.zaml:ro',
+		'-p 8449:8443',
+		'--detach',
+		'--name authzed-container',
+		'authzed/spicedb:latest',
+		'serve-testing',
+		'--http-enabled',
+		'--skip-release-check=true',
+		'--log-level debug',
+		'--load-configs ./schema.zaml',
+	].join(' ');
 
-  // turn on podman container for authzed
-  childProcess.exec(podmanCommand, {
-    cwd: path.join(__dirname, '..'),
-  }, (err) => {
-    if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
-      console.error('Error starting authzed podman container: Check status with `podman ps`', err);
-    } else {
-      console.info('Authzed podman container started successfully');
-    }
-  });
+	// turn on podman container for authzed
+	childProcess.exec(
+		podmanCommand,
+		{
+			cwd: path.join(__dirname, '..'),
+		},
+		(err) => {
+			if (err && !err.message.includes('the container name "authzed-container" is already in use')) {
+				console.error('Error starting authzed podman container: Check status with `podman ps`', err);
+			} else {
+				console.info('Authzed podman container started successfully');
+			}
+		},
+	);
 
-  console.info('Authzed podman container started successfully');
+	console.info('Authzed podman container started successfully');
 
-  console.info('Global setup complete');
+	console.info('Global setup complete');
 }

--- a/apps/organization_matchmaking/vitest.config.ts
+++ b/apps/organization_matchmaking/vitest.config.ts
@@ -42,7 +42,7 @@ export default defineWorkersConfig({
 							compatibilityFlags: ['nodejs_compat'],
 							entrypoint: 'AuthzedWorker',
 							bindings: {
-								AUTHZED_ENDPOINT: 'http://localhost:8443',
+								AUTHZED_ENDPOINT: 'http://localhost:8449',
 								AUTHZED_KEY: 'atoken',
 								AUTHZED_PREFIX: 'orbisops_catalyst_dev/',
 							},

--- a/run_local_dev.sh
+++ b/run_local_dev.sh
@@ -224,9 +224,9 @@ pushd ./apps > /dev/null
   # for development enabling grpc and http
   # 8443 is the default port for http
   # 50051 is the default port for grpc: use authzed/zed (see ReADME.md
-  AUTHZED_OUTPUT=$(podman run --rm -v ./authx_authzed_api/schema.zaml:/schema.zaml:ro \
+  AUTHZED_OUTPUT=$(podman run -v ./authx_authzed_api/schema.zaml:/schema.zaml:ro \
       -p 50051:50051 \
-      -p 8443:8443 --detach \
+      -p 8449:8443 --detach \
       --name $CONTAINER_NAME authzed/spicedb:latest \
       serve-testing --http-enabled --skip-release-check=true --log-level debug --load-configs ./schema.zaml 2>&1)
   podman_exit_code=$?

--- a/start_authzed.sh
+++ b/start_authzed.sh
@@ -59,7 +59,7 @@ print_header "Starting authzed container"
 printf "  ${CYAN}⏳ Launching podman container...${RESET}\n"
 pushd ./apps > /dev/null
   CONTAINER_NAME="authzed-container"
-  AUTHZED_OUTPUT=$(docker run -v ./authx_authzed_api/schema.zaml:/schema.zaml:ro \
+  AUTHZED_OUTPUT=$(podman run -v ./authx_authzed_api/schema.zaml:/schema.zaml:ro \
       -p $AUTHZED_RPC_PORT:50051 \
       -p $AUTHZED_HTTP_PORT:8443 --detach \
       --name $CONTAINER_NAME authzed/spicedb:latest \

--- a/start_authzed.sh
+++ b/start_authzed.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Script to start the Authzed (SpiceDB) container for local development
+
+BOLD="\033[1m"
+RESET="\033[0m"
+CYAN="\033[1;36m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RED="\033[1;31m"
+BLUE="\033[1;34m"
+MAGENTA="\033[1;35m"
+
+print_box() {
+  local text="$1"
+  local color="${2:-$BLUE}"
+  local width=70
+
+  printf "${color}"
+  printf "╭─%s╮\n" "$(printf "%${width}s" | tr ' ' '─')"
+  printf "│ %-${width}s│\n" "$text"
+  printf "╰─%s╯\n" "$(printf "%${width}s" | tr ' ' '─')"
+  printf "${RESET}"
+}
+
+print_step() {
+  local text="$1"
+  local color="${2:-$CYAN}"
+  printf "${color}• ${BOLD}%s${RESET}\n" "$text"
+}
+
+print_success() {
+  printf "${GREEN}✓ %s${RESET}\n" "$1"
+}
+
+print_warn() {
+  printf "${YELLOW}⚠️  %s${RESET}\n" "$1"
+}
+
+print_error() {
+  printf "${RED}✗ %s${RESET}\n" "$1"
+}
+
+print_header() {
+  local text="$1"
+  local color="${2:-$MAGENTA}"
+  local width=70
+
+  printf "\n${color}"
+  printf "╭%s╮\n" "$(printf "%${width}s" | tr ' ' '─')"
+  printf "│ ${BOLD}%-${width}s${RESET}${color} │\n" "$text"
+  printf "╰%s╯\n" "$(printf "%${width}s" | tr ' ' '─')"
+  printf "${RESET}\n"
+}
+
+AUTHZED_RPC_PORT=50051
+AUTHZED_HTTP_PORT=8449
+
+print_header "Starting authzed container"
+printf "  ${CYAN}⏳ Launching podman container...${RESET}\n"
+pushd ./apps > /dev/null
+  CONTAINER_NAME="authzed-container"
+  AUTHZED_OUTPUT=$(docker run -v ./authx_authzed_api/schema.zaml:/schema.zaml:ro \
+      -p $AUTHZED_RPC_PORT:50051 \
+      -p $AUTHZED_HTTP_PORT:8443 --detach \
+      --name $CONTAINER_NAME authzed/spicedb:latest \
+      serve-testing --http-enabled --skip-release-check=true --log-level debug --load-configs ./schema.zaml 2>&1)
+  podman_exit_code=$?
+
+  if [[ "$AUTHZED_OUTPUT" == *"the container name \"$CONTAINER_NAME\" is already in use"* ]]; then
+      print_success "Authzed container already running"
+  elif [[ "$podman_exit_code" -ne 0 ]]; then
+      print_error "Failed to start authzed container: $AUTHZED_OUTPUT"
+      exit 1
+  else
+      print_success "Started authzed container successfully"
+  fi
+popd > /dev/null
+
+print_box "🎉 Authzed container is running" "${GREEN}"


### PR DESCRIPTION
### TL;DR

Updated AuthZed port from 8443 to 8449 across all services to avoid port conflicts.

### What changed?

- Changed the AuthZed HTTP port from 8443 to 8449 in all configuration files, documentation, and scripts
- Updated port references in:
  - `.dev.vars.example` files
  - README documentation
  - Test configurations
  - Global setup scripts for various services
  - Vitest configuration files
  - Local development scripts
- Added a new `start_authzed.sh` script to simplify starting the AuthZed container
- Updated the data channel gateway dev port to 4008
- Removed unused helper functions in test files
- Fixed some code formatting issues

### How to test?

1. Run the new `start_authzed.sh` script to start the AuthZed container
2. Verify that AuthZed is accessible on port 8449
3. Run tests for the affected services to ensure they connect properly
4. Start the development environment using `run_local_dev.sh` and confirm all services work correctly

### Why make this change?

Port 8443 is commonly used by other services (particularly those using HTTPS), which could lead to port conflicts during local development. Changing to port 8449 reduces the likelihood of conflicts and ensures consistent behavior across all services that depend on AuthZed.