### PR TITLE
fix: ensure deleted API keys are properly invalidated and filtered from UI

### DIFF
--- a/apps/catalyst-ui-worker/tests/issued_jwt_registry.spec.ts
+++ b/apps/catalyst-ui-worker/tests/issued_jwt_registry.spec.ts
@@ -1,116 +1,126 @@
 // import "../../issued-jwt-registry/src/index"
-import { env } from "cloudflare:test";
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Logger } from "tslog";
-import { IssuedJWTRegistry } from "@catalyst/schema_zod";
+import { describe, it, expect } from 'vitest';
+import { env } from 'cloudflare:test';
+import { IssuedJWTRegistry } from '@catalyst/schema_zod';
 
-const logger = new Logger();
+describe('issued-jwt-registry unit tests', () => {
+    it('create issued-jwt-registry entry', async () => {
+        const newIJR = {
+            id: 'jwt_1',
+            name: 'my_first_jwt',
+            description: 'the first one we have ever tested',
+            claims: ['claim1', 'claim2'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+            organization: 'orbis_operations',
+        };
 
-describe("issued-jwt-registry unit tests", () => {
-  it("create issued-jwt-registry entry", async () => {
-    const newIJR = {
-      id: "jwt_1",
-      name: "my_first_jwt",
-      description: "the first one we have ever tested",
-      claims: ["claim1", "claim2"],
-      expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
-      organization: "orbis_operations",
-    };
+        const savedIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR);
 
-    const savedIJR = await env.ISSUED_JWT_WORKER.create(
-      "orbis_operations",
-      newIJR,
-    );
+        expect(savedIJR.id).toBeDefined();
+        expect(savedIJR.name).toBe('my_first_jwt');
+    });
 
-    expect(savedIJR.id).toBeDefined();
-    expect(savedIJR.name).toBe("my_first_jwt");
-  });
+    it('update issued-jwt-registry entry', async () => {
+        const changedIJR = {
+            id: 'jwt_1',
+            name: 'my_first_jwt',
+            description: 'the first one we have ever tested',
+            claims: ['claim1', 'claim2', 'claim3'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 48), //2 days from now
+            organization: 'orbis_operations',
+        };
 
-  it("update issued-jwt-registry entry", async () => {
-    const changedIJR = {
-      id: "jwt_1",
-      name: "my_first_jwt",
-      description: "the first one we have ever tested",
-      claims: ["claim1", "claim2", "claim3"],
-      expiry: new Date(Date.now() + 1000 * 60 * 60 * 48), //2 days from now
-      organization: "orbis_operations",
-    };
+        const savedChangedIJR = await env.ISSUED_JWT_WORKER.update('orbis_operations', changedIJR);
 
-    const savedChangedIJR = await env.ISSUED_JWT_WORKER.update(
-      "orbis_operations",
-      changedIJR,
-    );
+        expect(savedChangedIJR.id).toBeDefined();
+        expect(savedChangedIJR.name).toBe('my_first_jwt');
+        expect(savedChangedIJR.claims.length).toBe(3);
+        expect(savedChangedIJR.expiry).toStrictEqual(changedIJR.expiry);
+    });
 
-    expect(savedChangedIJR.id).toBeDefined();
-    expect(savedChangedIJR.name).toBe("my_first_jwt");
-    expect(savedChangedIJR.claims.length).toBe(3);
-    expect(savedChangedIJR.expiry).toStrictEqual(changedIJR.expiry);
-  });
+    it('get issued-jwt-registry entry, then delete it', async () => {
+        const anotherIJR = {
+            id: 'jwt_1',
+            name: 'my_third_jwt',
+            description: 'the third one we have ever tested',
+            claims: ['claim1', 'claim2', 'claim3'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 92), //days away
+            organization: 'orbis_operations',
+        };
+        const madeIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', anotherIJR);
+        const retrievedIJR: IssuedJWTRegistry | undefined = await env.ISSUED_JWT_WORKER.get(
+            'orbis_operations',
+            madeIJR.id
+        );
+        if (retrievedIJR) {
+            expect(retrievedIJR.id).toBeDefined();
+            expect(retrievedIJR.name).toStrictEqual(anotherIJR.name);
+            expect(retrievedIJR.claims.length).toBe(3);
+        } else {
+            throw new Error('Could not retrieve the issued JWT registry entry');
+        }
 
-  it("get issued-jwt-registry entry, then delete it", async () => {
-    const anotherIJR = {
-      id: "jwt_1",
-      name: "my_third_jwt",
-      description: "the third one we have ever tested",
-      claims: ["claim1", "claim2", "claim3"],
-      expiry: new Date(Date.now() + 1000 * 60 * 60 * 92), //days away
-      organization: "orbis_operations",
-    };
-    const madeIJR = await env.ISSUED_JWT_WORKER.create(
-      "orbis_operations",
-      anotherIJR,
-    );
-    const retrievedIJR: IssuedJWTRegistry | undefined =
-      await env.ISSUED_JWT_WORKER.get("orbis_operations", madeIJR.id);
-    if (retrievedIJR) {
-      expect(retrievedIJR.id).toBeDefined();
-      expect(retrievedIJR.name).toStrictEqual(anotherIJR.name);
-      expect(retrievedIJR.claims.length).toBe(3);
-    } else {
-      throw new Error("Could not retrieve the issued JWT registry entry");
-    }
+        const deletedIJR = await env.ISSUED_JWT_WORKER.delete('orbis_operations', retrievedIJR.id);
+        expect(deletedIJR).toBe(true);
+    });
 
-    const deletedIJR = await env.ISSUED_JWT_WORKER.delete(
-      "orbis_operations",
-      retrievedIJR.id,
-    );
-    expect(deletedIJR).toBe(true);
-  });
+    it('list issued-jwt-registry entries by organization claim', async () => {
+        const newIJR1 = {
+            id: 'jwt_1',
+            name: 'my_first_jwt',
+            description: 'the first one we have ever tested',
+            claims: ['claimA', 'claimX'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+            organization: 'orbis_operations',
+        };
 
-  it("list issued-jwt-registry entries by organization claim", async () => {
-    const newIJR1 = {
-      id: "jwt_1",
-      name: "my_first_jwt",
-      description: "the first one we have ever tested",
-      claims: ["claimA", "claimX"],
-      expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
-      organization: "orbis_operations",
-    };
+        const newIJR2 = {
+            id: 'jwt_2',
+            name: 'my_second_jwt',
+            description: 'the second one we have ever tested',
+            claims: ['claimA', 'claimB'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+            organization: 'orbis_operations',
+        };
 
-    const newIJR2 = {
-      id: "jwt_2",
-      name: "my_second_jwt",
-      description: "the second one we have ever tested",
-      claims: ["claimA", "claimB"],
-      expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
-      organization: "orbis_operations",
-    };
+        await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR1);
+        await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR2);
+        await env.ISSUED_JWT_WORKER.create('coverent', newIJR2);
+        const org1BasedIJRs = await env.ISSUED_JWT_WORKER.list('orbis_operations');
 
-    const madeIJR1 = await env.ISSUED_JWT_WORKER.create(
-      "orbis_operations",
-      newIJR1,
-    );
-    const madeIJR2 = await env.ISSUED_JWT_WORKER.create(
-      "orbis_operations",
-      newIJR2,
-    );
-    const madeIJR3 = await env.ISSUED_JWT_WORKER.create("coverent", newIJR2);
-    const org1BasedIJRs = await env.ISSUED_JWT_WORKER.list("orbis_operations");
+        const org2BasedIJRs = await env.ISSUED_JWT_WORKER.list('nc_state');
+        const org3BasedIJRs = await env.ISSUED_JWT_WORKER.list('coverent');
+        expect(org1BasedIJRs.length).toBe(2);
+        expect(org2BasedIJRs.length).toBe(0);
+        expect(org3BasedIJRs.length).toBe(1);
+    });
 
-    const org2BasedIJRs = await env.ISSUED_JWT_WORKER.list("nc_state");
-    const org3BasedIJRs = await env.ISSUED_JWT_WORKER.list("coverent");
-    expect(org1BasedIJRs.length).toBe(2);
-    expect(org2BasedIJRs.length).toBe(0);
-    expect(org3BasedIJRs.length).toBe(1);
-  });
+    it('list should not include deleted items', async () => {
+        const newIJR = {
+            id: 'jwt_1',
+            name: 'my_deletable_jwt',
+            description: 'this will be deleted',
+            claims: ['claimA'],
+            expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+            organization: 'orbis_operations',
+        };
+
+        const madeIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR);
+
+        // Verify it's in the list initially
+        const initialList = await env.ISSUED_JWT_WORKER.list('orbis_operations');
+        const initialCount = initialList.length;
+
+        // Delete the item
+        const deletedIJR = await env.ISSUED_JWT_WORKER.delete('orbis_operations', madeIJR.id);
+        expect(deletedIJR).toBe(true);
+
+        // Verify it's no longer in the list
+        const finalList = await env.ISSUED_JWT_WORKER.list('orbis_operations');
+        expect(finalList.length).toBe(initialCount - 1);
+
+        // Verify the deleted item is not in the final list
+        const deletedItemInList = finalList.find((item) => item.id === madeIJR.id);
+        expect(deletedItemInList).toBeUndefined();
+    });
 });

--- a/apps/data_channel_gateway/src/index.ts
+++ b/apps/data_channel_gateway/src/index.ts
@@ -241,8 +241,7 @@ const authenticateRequestMiddleware = async (c: Context<{ Bindings: Env; Variabl
         return c.json({ message: 'Token validation failed' }, 403);
     }
 
-    // if token is not on the revocation list, this function will return false
-    // else it checks the status against the revocation list
+    // Check if the JWT token is invalid (revoked or deleted)
     if (await c.env.ISSUED_JWT_REGISTRY.isInvalid(jwtId)) {
         return c.json({ message: 'Token has been revoked' }, 403);
     }

--- a/apps/data_channel_gateway/src/index.ts
+++ b/apps/data_channel_gateway/src/index.ts
@@ -242,8 +242,8 @@ const authenticateRequestMiddleware = async (c: Context<{ Bindings: Env; Variabl
     }
 
     // if token is not on the revocation list, this function will return false
-    // else it checks the status agains ENUM.revoked
-    if (await c.env.ISSUED_JWT_REGISTRY.isOnRevocationList(jwtId)) {
+    // else it checks the status against the revocation list
+    if (await c.env.ISSUED_JWT_REGISTRY.isInvalid(jwtId)) {
         return c.json({ message: 'Token has been revoked' }, 403);
     }
 

--- a/apps/issued-jwt-registry/src/index.ts
+++ b/apps/issued-jwt-registry/src/index.ts
@@ -95,10 +95,10 @@ export default class IssuedJWTRegistryWorker extends WorkerEntrypoint<Env> {
 		const stub = this.env.ISSUED_JWT_REGISTRY_DO.get(doId);
 		return await stub.removeFromRevocationList(issuedJWTRegId);
 	}
-	async isOnRevocationList(issuedJWTRegId: string, doNamespace: string = 'default') {
+	async isInvalid(issuedJWTRegId: string, doNamespace: string = 'default') {
 		const doId = this.env.ISSUED_JWT_REGISTRY_DO.idFromName(doNamespace);
 		const stub = this.env.ISSUED_JWT_REGISTRY_DO.get(doId);
-		return await stub.isOnRevocationList(issuedJWTRegId);
+		return await stub.isInvalid(issuedJWTRegId);
 	}
 }
 
@@ -166,7 +166,7 @@ export class I_JWT_Registry_DO extends DurableObject {
 		return status;
 	}
 
-	async isOnRevocationList(id: string) {
+	async isInvalid(id: string) {
 		const ijr = await this.get(id);
 		return ijr ? ijr.status === JWTRegisterStatus.enum.revoked || ijr.status === JWTRegisterStatus.enum.deleted : false;
 	}

--- a/apps/issued-jwt-registry/tests/issued_jwt_registry.spec.ts
+++ b/apps/issued-jwt-registry/tests/issued_jwt_registry.spec.ts
@@ -177,7 +177,7 @@ describe('issued-jwt-registry unit tests', () => {
 		expect(cantRevoke).toBe(false);
 	});
 
-	it('can add items to the revocatoion list', async () => {
+	it('can add items to the revocation list', async () => {
 		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
@@ -191,18 +191,18 @@ describe('issued-jwt-registry unit tests', () => {
 			status: 'active',
 		});
 
-		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
+		expect(await stub.isInvalid(item1.id)).toBe(false);
 
 		expect(await stub.addToRevocationList(item1.id)).toBe(true);
 
-		expect(await stub.isOnRevocationList(item1.id)).toBe(true);
+		expect(await stub.isInvalid(item1.id)).toBe(true);
 
 		expect(await stub.removeFromRevocationList(item1.id)).toBe(true);
 
-		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
+		expect(await stub.isInvalid(item1.id)).toBe(false);
 	});
 
-	it('deleted items are considered to be on revocation list', async () => {
+	it('deleted items are considered invalid', async () => {
 		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
@@ -216,12 +216,12 @@ describe('issued-jwt-registry unit tests', () => {
 			status: 'active',
 		});
 
-		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
+		expect(await stub.isInvalid(item1.id)).toBe(false);
 
 		// Delete the item
 		await stub.delete(item1.id);
 
 		// Verify deleted items are considered to be on revocation list
-		expect(await stub.isOnRevocationList(item1.id)).toBe(true);
+		expect(await stub.isInvalid(item1.id)).toBe(true);
 	});
 });

--- a/apps/issued-jwt-registry/tests/issued_jwt_registry.spec.ts
+++ b/apps/issued-jwt-registry/tests/issued_jwt_registry.spec.ts
@@ -1,210 +1,194 @@
-// @ts-ignore
-import { IssuedJWTRegistry, JWTRegisterStatus } from '@catalyst/schema_zod';
-import { env, ProvidedEnv, createExecutionContext, SELF, listDurableObjectIds, runInDurableObject,} from 'cloudflare:test';
-import {describe, it, expect, beforeAll, afterAll} from "vitest";
+// @ts-expect-error: Some environments require this import for type checking
+import { env } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
 
-describe("issued-jwt-registry unit tests", () => {
-	it("create issued-jwt-registry entry", async () => {
+describe('issued-jwt-registry unit tests', () => {
+	it('create issued-jwt-registry entry', async () => {
+		const newIJR = {
+			id: 'jwt_1',
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+		};
 
-		const newIJR =	{
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe"
-		}
-
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
 		const resp = await stub.create(newIJR);
-		console.error('resp', resp)
+		console.error('resp', resp);
 
 		expect(newIJR.id).toBeDefined();
-		expect(newIJR.name).toBe("my_first_jwt");
-	})
+		expect(newIJR.name).toBe('my_first_jwt');
+	});
 
-	it("get an issued-jwt-registry entry", async () => {
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+	it('get an issued-jwt-registry entry', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
-		const newIJR =	{
+		const newIJR = {
 			//id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe"
-		}
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+		};
 		const newIJRResp = await stub.create(newIJR);
 		const resp = await stub.get(newIJRResp.id);
-		console.error(resp)
+		console.error(resp);
 		expect(resp).toBeDefined();
 		expect(resp.name).toBe(newIJR.name);
-	})
+	});
 
-	it("can list issued-jwt-registry entries", async () => {
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+	it('can list issued-jwt-registry entries', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
-		const newIJR =	{
+		const newIJR = {
 			//id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1"
-		}
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+		};
 		const newIJRResp = await stub.create(newIJR);
 		expect(newIJRResp).toBeDefined();
 
-		const list1Entry = await stub.list("org 1");
+		const list1Entry = await stub.list('org 1');
 		expect(list1Entry).toBeDefined();
 		expect(list1Entry.length).toBe(1);
 
-		expect(await stub.list("org 2")).toHaveLength(0);
-	})
+		expect(await stub.list('org 2')).toHaveLength(0);
+	});
 
-	it("can change status - item guard", async () => {
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+	it('can change status - item guard', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
 		const activeResp = await stub.JWTRegistryItemGuard({
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "active"
+			id: 'jwt_1',
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'active',
 		});
-		console.error(activeResp)
+		console.error(activeResp);
 		expect(activeResp[0]).toBe(true);
 		expect(activeResp[1]).toBe(false);
 
 		const revokedResp = await stub.JWTRegistryItemGuard({
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "revoked"
+			id: 'jwt_1',
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'revoked',
 		});
 
 		expect(revokedResp[0]).toBe(true);
 		expect(revokedResp[1]).toBe(false);
 
 		const deletedResp = await stub.JWTRegistryItemGuard({
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "deleted"
-		});
-
-		expect(deletedResp[0]).toBe(false);
-		expect(deletedResp[1]).toBe(false);
-
-		const expiredResp = await stub.JWTRegistryItemGuard({
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "expired"
+			id: 'jwt_1',
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'deleted',
 		});
 
 		expect(deletedResp[0]).toBe(false);
 		expect(deletedResp[1]).toBe(false);
 
 		const activeExpiredResp = await stub.JWTRegistryItemGuard({
-			id: "jwt_1",
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() - (1000 * 60 * 60 * 60)),
-			organization: "org 1",
-			status: "active"
+			id: 'jwt_1',
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() - 1000 * 60 * 60 * 60),
+			organization: 'org 1',
+			status: 'active',
 		});
 
 		expect(activeExpiredResp[0]).toBe(false);
 		expect(activeExpiredResp[1]).toBe(true);
-	})
+	});
 
-	it("updated status of issued-jwt-registry entry", async () => {
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+	it('updated status of issued-jwt-registry entry', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
 		const activeResp = await stub.create({
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "active"
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'active',
 		});
 
 		// move status to revoked
-		const revoked = await stub.changeStatus(activeResp.id, "revoked");
-		expect(revoked).toBe(true)
+		const revoked = await stub.changeStatus(activeResp.id, 'revoked');
+		expect(revoked).toBe(true);
 
-		const deleted = await stub.changeStatus(activeResp.id, "deleted");
-		expect(deleted).toBe(true)
+		const deleted = await stub.changeStatus(activeResp.id, 'deleted');
+		expect(deleted).toBe(true);
 
-		const makeActive = await stub.changeStatus(activeResp.id, "active");
-		expect(makeActive).toBe(false)
+		const makeActive = await stub.changeStatus(activeResp.id, 'active');
+		expect(makeActive).toBe(false);
 
 		// set as expired
 		const expiredStatusResp = await stub.create({
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "expired"
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'expired',
 		});
 
-		const cantDelete = await stub.changeStatus(expiredStatusResp.id, "deleted");
-		expect(cantDelete).toBe(false)
+		const cantDelete = await stub.changeStatus(expiredStatusResp.id, 'deleted');
+		expect(cantDelete).toBe(false);
 
 		const expiredResp = await stub.create({
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() - (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "active"
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() - 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'active',
 		});
 
-		const cantRevoke = await stub.changeStatus(expiredResp.id, "revoked");
-		expect(cantRevoke).toBe(false)
-	})
+		const cantRevoke = await stub.changeStatus(expiredResp.id, 'revoked');
+		expect(cantRevoke).toBe(false);
+	});
 
-	it("can add items to the revocatoion list", async () => {
-		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName("creation");
+	it('can add items to the revocatoion list', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
 		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
 
 		const item1 = await stub.create({
-			name: "my_first_jwt",
-			description: "the first one we have ever tested",
-			claims: ["claim1", "claim2"],
-			expiry:  new Date(Date.now() + (1000 * 60 * 60 * 24)), //tomorrow
-			hash: "alsdfanlkweopivnweoiwe",
-			organization: "org 1",
-			status: "active"
+			name: 'my_first_jwt',
+			description: 'the first one we have ever tested',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'active',
 		});
 
 		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
@@ -216,6 +200,28 @@ describe("issued-jwt-registry unit tests", () => {
 		expect(await stub.removeFromRevocationList(item1.id)).toBe(true);
 
 		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
+	});
 
-	})
+	it('deleted items are considered to be on revocation list', async () => {
+		const id = env.ISSUED_JWT_REGISTRY_DO.idFromName('creation');
+		const stub = env.ISSUED_JWT_REGISTRY_DO.get(id);
+
+		const item1 = await stub.create({
+			name: 'my_deletable_jwt',
+			description: 'this will be deleted',
+			claims: ['claim1', 'claim2'],
+			expiry: new Date(Date.now() + 1000 * 60 * 60 * 24), //tomorrow
+			hash: 'alsdfanlkweopivnweoiwe',
+			organization: 'org 1',
+			status: 'active',
+		});
+
+		expect(await stub.isOnRevocationList(item1.id)).toBe(false);
+
+		// Delete the item
+		await stub.delete(item1.id);
+
+		// Verify deleted items are considered to be on revocation list
+		expect(await stub.isOnRevocationList(item1.id)).toBe(true);
+	});
 });


### PR DESCRIPTION
### TL;DR

The "delete" button for API keys in the UI actually makes the keys invalid for accessing associated data channels, as well as makes them no longer show up in the UI.


### What changed?

- Modified the `list` method in `I_JWT_Registry_DO` to filter out items with `deleted` status
- Updated `isOnRevocationList` to consider deleted items as revoked
- Added new test cases to verify deleted items are properly handled:
  - Deleted items are excluded from list results
  - Deleted items are considered to be on the revocation list
- Improved code formatting and style consistency across files
- Removed unused imports and variables

### How to test?
1) Delete an API key in the UI.
2) Verify it no longer shows up in API key UI view (it did before)
3) Verify it's no longer usable to receive data from a data channel (it was still usable before)

OR

1. Run the test suite for the issued-jwt-registry module
2. Verify the new test cases pass:
   - `list should not include deleted items` in catalyst-ui-worker tests
   - `deleted items are considered to be on revocation list` in issued-jwt-registry tests



### Why make this change?

This change improves security and usability by ensuring deleted JWT tokens are properly handled. Previously, deleted items might still appear in lists and weren't automatically considered revoked, which could lead to security issues if deleted tokens were still being used. The implementation now correctly filters deleted items from lists and treats them as revoked, providing a more secure and consistent behavior.