### PR TITLE
fix(workflows): updated github workflows to use Node 20

### DIFF
--- a/.github/workflows/dependency_management.yaml
+++ b/.github/workflows/dependency_management.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm

--- a/.github/workflows/deployment_to_demo.yaml
+++ b/.github/workflows/deployment_to_demo.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 20
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/deployment_to_staging.yaml
+++ b/.github/workflows/deployment_to_staging.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 20
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
### TL;DR

Upgraded Node.js version from 18 to 20 in GitHub workflow files.

### What changed?

Updated the Node.js version from 18 to 20 in three GitHub workflow files:
- `.github/workflows/dependency_management.yaml`
- `.github/workflows/deployment_to_demo.yaml`
- `.github/workflows/deployment_to_staging.yaml`

This ensures all CI/CD pipelines use Node.js 20 consistently.

### How to test?

1. Verify that the GitHub workflows run successfully with the new Node.js version
2. Check that all build, test, and deployment processes complete without errors
3. Confirm that the application functions correctly in demo and staging environments

### Why make this change?

Node.js 18 is approaching end-of-life (April 2025), while Node.js 20 is the current LTS version with longer support. Upgrading ensures we're using a more modern runtime with better performance, security updates, and access to newer JavaScript features.