### PR TITLE
Fix typo in CheckResponse and add ESLint disables

### DIFF
--- a/apps/authx_authzed_api/src/authzed.ts
+++ b/apps/authx_authzed_api/src/authzed.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Authzed, Catalyst, DataChannelId, OrgId, UserId } from '@catalyst/schema_zod';
 
 export type SearchInfoBody = {
@@ -261,9 +264,9 @@ export class AuthzedClient {
 		},
 	) {
 		const searchRoles = args.roles ?? [Catalyst.RoleEnum.enum.user, Catalyst.RoleEnum.enum.data_custodian, Catalyst.RoleEnum.enum.admin];
-		console.log(searchRoles)
+		console.log(searchRoles);
 
-		let results: Catalyst.Relationship[] = [];
+		const results: Catalyst.Relationship[] = [];
 
 		for (const role of searchRoles) {
 			const body = this.utils.readRelationship({
@@ -303,8 +306,8 @@ export class AuthzedClient {
 		const { data } = await this.utils.permissionFetcher(req);
 
 		const permissionResp = Authzed.Permissions.Response.parse(data);
-		if (typeof permissionResp === typeof Authzed.Permissions.CheckReponse) {
-			const response = Authzed.Permissions.CheckReponse.safeParse(permissionResp);
+		if (typeof permissionResp === typeof Authzed.Permissions.CheckResponse) {
+			const response = Authzed.Permissions.CheckResponse.safeParse(permissionResp);
 			return response.success && response.data.permissionship === Authzed.Permissions.PermissionValues.enum.PERMISSIONSHIP_HAS_PERMISSION;
 		}
 		return false;
@@ -362,14 +365,14 @@ export class AuthzedClient {
 		const req = this.utils.checkDataChannelPermission(dataChannelId, userId, permission);
 		const { data } = await this.utils.permissionFetcher(req);
 
-		const resp = Authzed.Permissions.CheckReponse.safeParse(data);
+		const resp = Authzed.Permissions.CheckResponse.safeParse(data);
 		if (!resp.success) {
 			console.error(resp.error, 'data channel permission check failed', dataChannelId, userId, permission);
 			return false;
 		}
 		const permissionResp = resp.data;
-		if (typeof permissionResp === typeof Authzed.Permissions.CheckReponse) {
-			const success = Authzed.Permissions.CheckReponse.parse(permissionResp);
+		if (typeof permissionResp === typeof Authzed.Permissions.CheckResponse) {
+			const success = Authzed.Permissions.CheckResponse.parse(permissionResp);
 			return success.permissionship === Authzed.Permissions.PermissionValues.enum.PERMISSIONSHIP_HAS_PERMISSION;
 		}
 		return false;
@@ -497,7 +500,7 @@ export class AuthzedUtils {
 	}
 
 	parseNDJONFromAuthzed(rawData: string): any[] {
-		let parsedData: any[] = [];
+		const parsedData: any[] = [];
 		rawData.split('\n').forEach((row) => {
 			if (row.length > 0) {
 				parsedData.push(JSON.parse(row) as Authzed.Relationships.ReadResult);

--- a/packages/schema_zod/authzed/permissions/check.ts
+++ b/packages/schema_zod/authzed/permissions/check.ts
@@ -1,36 +1,38 @@
 import { z } from 'zod';
 
 export const CheckError = z.object({
-  code: z.number(),
-  message: z.string(),
-  details: z.object({
-    "@type" : z.string().optional(),
-    eiusmod93: z.object({}).optional(),
-    labore2e: z.object({}).optional(),
-    in_81a: z.object({}).optional()
-  }).array()
-})
+    code: z.number(),
+    message: z.string(),
+    details: z
+        .object({
+            '@type': z.string().optional(),
+            eiusmod93: z.object({}).optional(),
+            labore2e: z.object({}).optional(),
+            in_81a: z.object({}).optional(),
+        })
+        .array(),
+});
 
-export const PermissionValues = z.enum([
-  "PERMISSIONSHIP_HAS_PERMISSION",
-  "PERMISSIONSHIP_NO_PERMISSION"])
+export const PermissionValues = z.enum(['PERMISSIONSHIP_HAS_PERMISSION', 'PERMISSIONSHIP_NO_PERMISSION']);
 
-export type PermissionValues = z.infer<typeof PermissionValues>
-export const  CheckReponse = z.object({
-  checkedAt: z.object({
-    token: z.string()
-  }),
-  permissionship: PermissionValues,
-  partialCaveatInfo: z.object({
-    missingRequiredContext: z.string().array()
-  }).nullish().optional()
-})
+export type PermissionValues = z.infer<typeof PermissionValues>;
+export const CheckResponse = z.object({
+    checkedAt: z.object({
+        token: z.string(),
+    }),
+    permissionship: PermissionValues,
+    partialCaveatInfo: z
+        .object({
+            missingRequiredContext: z.string().array(),
+        })
+        .nullish()
+        .optional(),
+    debugTrace: z.any().nullable().optional(),
+    optionalExpiresAt: z.any().nullable().optional(),
+});
 
-export const Response = z.union([
-  CheckReponse,
-  CheckError
-])
+export const Response = z.union([CheckResponse, CheckError]);
 
-export type CheckReponse = z.infer<typeof  CheckReponse>
-export type CheckError = z.infer<typeof CheckError>
-export type Response = z.infer<typeof Response>
+export type CheckResponse = z.infer<typeof CheckResponse>;
+export type CheckError = z.infer<typeof CheckError>;
+export type Response = z.infer<typeof Response>;


### PR DESCRIPTION
### TL;DR

Fixed a typo in the AuthZed permission check response type and improved code quality.

### What changed?

- Renamed `CheckReponse` to `CheckResponse` to fix the typo in both the AuthZed client and schema
- Added missing fields to the `CheckResponse` schema: `debugTrace` and `optionalExpiresAt`
- Changed `let` to `const` for immutable variables
- Added ESLint disable comments for specific rules in the authzed.ts file
- Fixed formatting and indentation in the schema file
- Added a semicolon after a console.log statement

### How to test?

1. Run the existing tests to ensure the permission checks still work correctly
2. Verify that permission checks using the AuthZed client return the expected results
3. Ensure that the code compiles without TypeScript errors

### Why make this change?

The primary issue was a typo in the `CheckReponse` type name, which could lead to confusion and potential bugs. This change ensures consistency in naming and improves type safety. The additional fields in the schema ensure compatibility with the actual API responses from AuthZed. The other changes improve code quality and maintainability by following best practices for variable declarations and formatting.