### PR TITLE
fix: add port to preview local opennext js

### DIFF
--- a/apps/catalyst-ui-worker/package.json
+++ b/apps/catalyst-ui-worker/package.json
@@ -9,7 +9,7 @@
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,md,json}\"",
-        "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+        "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview -- --port=4000",
         "deploy:uxr": "opennextjs-cloudflare build && opennextjs-cloudflare deploy -- --env=uxr",
         "deploy:staging": "opennextjs-cloudflare build && opennextjs-cloudflare deploy -- --env=staging",
         "deploy:preview": "opennextjs-cloudflare build && opennextjs-cloudflare deploy -- --env=preview",


### PR DESCRIPTION
### TL;DR

Updated the preview command to use port 4000 for the catalyst-ui-worker application.

### What changed?

Modified the `preview` script in the `package.json` file to specify port 4000 when running the preview command. The command now includes the additional parameter `-- --port=4000`.

### How to test?

1. Run `npm run preview` or `yarn preview` in the catalyst-ui-worker directory
2. Verify that the application is accessible on port 4000 (http://localhost:4000)
3. Confirm that the preview functionality works as expected on the specified port

### Why make this change?

This change ensures the preview server runs on a consistent port (4000), which helps prevent port conflicts with other services and provides developers with a predictable URL for local testing. This is especially useful in development environments where multiple services might be running simultaneously.