### PR TITLE
fix: add casting to new unknowns

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/channels.ts
+++ b/apps/catalyst-ui-worker/app/actions/channels.ts
@@ -1,7 +1,6 @@
 'use server';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { DataChannel } from '@catalyst/schema_zod';
-import { CloudflareEnv } from '@/env';
 
 function getEnv() {
     return getCloudflareContext().env as CloudflareEnv;

--- a/apps/catalyst-ui-worker/app/actions/i-jwt-registry.ts
+++ b/apps/catalyst-ui-worker/app/actions/i-jwt-registry.ts
@@ -1,5 +1,4 @@
 'use server';
-import { CloudflareEnv } from '@/env';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { IssuedJWTRegistry } from '@catalyst/schema_zod';
 function getEnv() {

--- a/apps/catalyst-ui-worker/app/actions/tokens.ts
+++ b/apps/catalyst-ui-worker/app/actions/tokens.ts
@@ -1,5 +1,4 @@
 'use server';
-import { CloudflareEnv } from '@/env';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { JWTRequest } from '../types';
 import { DEFAULT_STANDARD_DURATIONS } from '@catalyst/schema_zod';

--- a/apps/catalyst-ui-worker/components/channels/ChannelDetails.tsx
+++ b/apps/catalyst-ui-worker/components/channels/ChannelDetails.tsx
@@ -174,7 +174,7 @@ export default function DataChannelDetailsComponent({
                                             const formData = new FormData(e.currentTarget);
                                             if (editChannel && token) {
                                                 formData.append('id', editChannel.id);
-                                                formData.append('organization', user?.custom.org);
+                                                formData.append('organization', String(user?.custom.org));
                                                 formData.set(
                                                     'name',
 
@@ -196,7 +196,7 @@ export default function DataChannelDetailsComponent({
                                             <FormControl display={'grid'} gap={2}>
                                                 <label htmlFor="name">Data Channel Name</label>
                                                 <InputGroup>
-                                                    <InputLeftAddon>{user?.custom.org}/</InputLeftAddon>
+                                                    <InputLeftAddon>{`${user?.custom.org ?? ''}/`}</InputLeftAddon>
                                                     <Input
                                                         rounded="md"
                                                         name="name"

--- a/apps/catalyst-ui-worker/components/channels/CreateChannelForm.tsx
+++ b/apps/catalyst-ui-worker/components/channels/CreateChannelForm.tsx
@@ -21,7 +21,7 @@ export default function CreateChannelForm({ createDataChannel }: DataChannelForm
         name: '',
         description: '',
         endpoint: '',
-        creatorOrganization: user?.custom.org,
+        creatorOrganization: String(user?.custom.org),
         accessSwitch: true,
     });
     return (
@@ -48,7 +48,7 @@ export default function CreateChannelForm({ createDataChannel }: DataChannelForm
                     <CardBody>
                         <form
                             action={async (fd) => {
-                                fd.set('organization', user?.custom.org);
+                                fd.set('organization', String(user?.custom.org));
                                 fd.set('name', user?.custom.org + '/' + fd.get('name'));
                                 createDataChannel(fd, token ?? '')
                                     .then((newChannel) => {
@@ -64,7 +64,7 @@ export default function CreateChannelForm({ createDataChannel }: DataChannelForm
                                 <FormControl display={'grid'} gap={2}>
                                     <label htmlFor="name">Data Channel Name</label>
                                     <InputGroup>
-                                        <InputLeftAddon>{user?.custom.org}/</InputLeftAddon>
+                                        <InputLeftAddon>{String(user?.custom.org)}/</InputLeftAddon>
 
                                         <Input
                                             rounded="md"

--- a/apps/catalyst-ui-worker/components/layouts/components/index.tsx
+++ b/apps/catalyst-ui-worker/components/layouts/components/index.tsx
@@ -20,10 +20,10 @@ export const TopBar = (props: TopBarProps) => {
 
     useEffect(() => {
         if (user) {
-            if (typeof window !== 'undefined') window.localStorage.setItem('org', user.custom.org);
-            setOrgName(user.custom.org);
+            if (typeof window !== 'undefined') window.localStorage.setItem('org', String(user.custom.org));
+            setOrgName(String(user.custom.org));
             if (typeof window !== 'undefined') {
-                window.localStorage.setItem('org', user.custom.org);
+                window.localStorage.setItem('org', String(user.custom.org));
             }
         }
     }, [user?.custom.org]);

--- a/apps/catalyst-ui-worker/components/tokens/ListTokens.tsx
+++ b/apps/catalyst-ui-worker/components/tokens/ListTokens.tsx
@@ -48,7 +48,7 @@ export default function APIKeysComponent({ listIJWTRegistry, deleteIJWTRegistry 
         setHasError(false);
         setIsLoading(true);
         if (user !== undefined && token !== undefined) {
-            setAdminFlag(user && token && user?.custom.isPlatformAdmin);
+            setAdminFlag(!!user?.custom.isPlatformAdmin);
             listIJWTRegistry(token)
                 .then((data) => {
                     setIsLoading(false);
@@ -216,7 +216,8 @@ export default function APIKeysComponent({ listIJWTRegistry, deleteIJWTRegistry 
                             ) : (
                                 <Card>
                                     <CardBody>
-                                        No tokens exist for {user !== undefined ? user.custom.org : 'this user'}!
+                                        No tokens exist for{' '}
+                                        {user !== undefined ? (user.custom.org as string) : 'this user'}!
                                     </CardBody>
                                 </Card>
                             )}


### PR DESCRIPTION
### TL;DR

Fixed type safety issues with user organization data by explicitly converting organization values to strings.

### What changed?

- Added explicit string type conversions for `user?.custom.org` values throughout the codebase
- Removed unused CloudflareEnv imports from server action files
- Added null coalescing operator for organization display in UI components
- Fixed a boolean conversion in the token listing component

### How to test?

1. Log in with different user accounts to verify organization information displays correctly
2. Create and edit data channels to ensure organization information is properly saved
3. Check token listings to confirm they display correctly for both admin and non-admin users

### Why make this change?

The application was experiencing type safety issues when handling organization data from user objects. The organization value wasn't being properly converted to strings in form submissions and UI displays, which could lead to unexpected behavior. This change ensures consistent string handling of organization values throughout the application.