### PR TITLE
refactor: standardize service ports to sequential

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,22 @@
 # Just run for all the apps right now
-pnpm syncpack:fix --source apps/authx_authzed_api/package.json 
-pnpm syncpack:fix --source apps/authx_token_api/package.json 
-pnpm syncpack:fix --source apps/data_channel_gateway/package.json 
-pnpm syncpack:fix --source apps/data_channel_registrar/package.json 
-pnpm syncpack:fix --source apps/issued-jwt-registry/package.json 
-pnpm syncpack:fix --source apps/organization_matchmaking/package.json 
+
+pnpm syncpack:fix --source apps/authx_authzed_api/package.json
+pnpm syncpack:fix --source apps/authx_token_api/package.json
+pnpm syncpack:fix --source apps/data_channel_gateway/package.json
+pnpm syncpack:fix --source apps/data_channel_registrar/package.json
+pnpm syncpack:fix --source apps/issued-jwt-registry/package.json
+pnpm syncpack:fix --source apps/organization_matchmaking/package.json
 pnpm syncpack:fix --source apps/user-credentials-cache/package.json
 pnpm syncpack:fix --source apps/catalyst-ui-worker/package.json
+
+# Abort commit only if syncpack modified targeted package.json files
+
+TARGETS="apps/authx_authzed_api/package.json apps/authx_token_api/package.json apps/data_channel_gateway/package.json apps/data_channel_registrar/package.json apps/issued-jwt-registry/package.json apps/organization_matchmaking/package.json apps/user-credentials-cache/package.json apps/catalyst-ui-worker/package.json"
+if ! git diff --quiet -- $TARGETS; then
+echo "Pre-commit: syncpack changed package.json files. Please review and stage them."
+echo "Aborting commit."
+exit 1
+fi
 
 pnpm lint-staged
 

--- a/README.md
+++ b/README.md
@@ -102,17 +102,20 @@ For detailed information about each component, please refer to the individual RE
 
 When running the local development environment using `./run_local_dev.sh`, the following services are started on their respective ports:
 
-| Service                    | Port   | Description                                             |
-| -------------------------- | ------ | ------------------------------------------------------- |
-| `catalyst-ui-worker`       | 4000   | The main web interface for Catalyst.                    |
-| `data_channel_gateway`     | 4008   | Federates data channels into a single GraphQL endpoint. |
-| `authx_authzed_api`        | 5050   | Core authorization service using Authzed/SpiceDB.       |
-| `data_channel_registrar`   | 5053   | Manages data channel discovery and registration.        |
-| `organization_matchmaking` | 8787\* | Manages organization partnerships and invitations.      |
-| `authx_token_api`          | 5051   | Issues and signs service-to-service JWTs.               |
-| `user-credentials-cache`   | 8787\* | Caches user identity information from auth provider.    |
-| `issued-jwt-registry`      | 5054   | Tracks and validates issued JWTs.                       |
-| `authzed-container` (gRPC) | 50051  | The gRPC port for the Authzed/SpiceDB container.        |
-| `authzed-container` (HTTP) | 8449   | The HTTP port for the Authzed/SpiceDB container.        |
+| Service                    | Port | Inspector Port | Description                                             |
+| -------------------------- | ---- | -------------- | ------------------------------------------------------- |
+| `catalyst-ui-worker`       | 4000 | -              | The main web interface for Catalyst.                    |
+| `authx_authzed_api`        | 4001 | 6001           | Core authorization service using Authzed/SpiceDB.       |
+| `authx_token_api`          | 4002 | 6002           | Issues and signs service-to-service JWTs.               |
+| `user-credentials-cache`   | 4003 | 6003           | Caches user identity information from auth provider.    |
+| `data_channel_registrar`   | 4004 | 6004           | Manages data channel discovery and registration.        |
+| `issued-jwt-registry`      | 4005 | 6005           | Tracks and validates issued JWTs.                       |
+| `data_channel_gateway`     | 4006 | 6006           | Federates data channels into a single GraphQL endpoint. |
+| `organization_matchmaking` | 4007 | 6007           | Manages organization partnerships and invitations.      |
 
-_Note: Services running on port 8787 use the default Wrangler port. If multiple services run without a specified port, Wrangler will automatically assign the next available port (e.g., 8788, 8789)._
+Authzed container (if used locally):
+
+| Service                    | Port  |
+| -------------------------- | ----- |
+| `authzed-container` (gRPC) | 50051 |
+| `authzed-container` (HTTP) | 8449  |

--- a/apps/authx_authzed_api/package.json
+++ b/apps/authx_authzed_api/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"dev": "wrangler dev --port 5050",
+		"dev": "wrangler dev --port 4001 --inspector-port 6001",
 		"deploy:uxr": "wrangler deploy --env uxr",
 		"deploy:staging": "wrangler deploy --env staging",
 		"deploy:preview": "wrangler deploy --env preview",

--- a/apps/authx_token_api/package.json
+++ b/apps/authx_token_api/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"deploymentDemo": "yes | wrangler deploy --minify --keep-vars --env demo",
 		"deploymentStaging": "yes | wrangler deploy --keep-vars --env staging",
-		"dev": "wrangler dev --port 5051",
+		"dev": "wrangler dev --port 4002 --inspector-port 6002",
 		"deploy:uxr": "wrangler deploy --env uxr",
 		"deploy:staging": "wrangler deploy --env staging",
 		"deploy:preview": "wrangler deploy --env preview",

--- a/apps/catalyst-ui-worker/package.json
+++ b/apps/catalyst-ui-worker/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "build": "next build",
-        "dev": "next dev --port 4000",
+        "dev": "NODE_OPTIONS='--inspect' next dev --port 4000",
         "start": "next start",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
@@ -37,7 +37,6 @@
     },
     "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.8.23",
-        "@cloudflare/workers-types": "^4.20250525.0",
         "wrangler": "^4.19.1",
         "@eslint/compat": "^1.2.8",
         "@eslint/eslintrc": "^3.0.5",

--- a/apps/catalyst-ui-worker/tests/tsconfig.json
+++ b/apps/catalyst-ui-worker/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-pool-workers"]
+        "types": ["@cloudflare/vitest-pool-workers"]
     },
-    "include": ["./**/*.ts", "../src/env.d.ts"],
+    "include": ["./**/*.ts"],
     "exclude": []
 }

--- a/apps/catalyst-ui-worker/tsconfig.json
+++ b/apps/catalyst-ui-worker/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["dom", "dom.iterable", "ESNext"],
-        "types": ["@cloudflare/workers-types"],
+
         "allowJs": true,
         "skipLibCheck": true,
         "strict": true,
@@ -25,6 +25,6 @@
         },
         "target": "ES2017"
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "env.d.ts", ".next/types/**/*.ts"],
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
     "exclude": ["node_modules"]
 }

--- a/apps/data_channel_gateway/package.json
+++ b/apps/data_channel_gateway/package.json
@@ -2,7 +2,7 @@
     "name": "@catalyst/data_channel_gateway",
     "type": "module",
     "scripts": {
-        "dev": "wrangler dev --port 4008",
+        "dev": "wrangler dev --port 4006 --inspector-port 6006",
         "deploy:uxr": "wrangler deploy --env uxr",
         "deploy:staging": "wrangler deploy --env staging",
         "deploy:preview": "wrangler deploy --env preview",

--- a/apps/data_channel_registrar/package.json
+++ b/apps/data_channel_registrar/package.json
@@ -8,7 +8,7 @@
     "test": "vitest",
     "test:workspace": "vitest run --silent",
     "test:coverage": "vitest --coverage",
-    "dev": "pnpm wrangler dev --port 5053",
+    "dev": "pnpm wrangler dev --port 4004 --inspector-port 6004",
     "deploy": "wrangler deploy --minify src/worker.ts",
     "deploy:uxr": "wrangler deploy --env uxr",
     "deploy:staging": "wrangler deploy --env staging",

--- a/apps/issued-jwt-registry/package.json
+++ b/apps/issued-jwt-registry/package.json
@@ -4,7 +4,7 @@
 	"main": "index.ts",
 	"type": "module",
 	"scripts": {
-		"dev": "wrangler dev --port 5054",
+		"dev": "wrangler dev --port 4005 --inspector-port 6005",
 		"deploy:uxr": "wrangler deploy --env uxr",
 		"deploy:staging": "wrangler deploy --env staging",
 		"deploy:preview": "wrangler deploy --env preview",

--- a/apps/organization_matchmaking/package.json
+++ b/apps/organization_matchmaking/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "wrangler dev --port 4007 --inspector-port 6007",
 		"deploy:uxr": "wrangler deploy --env uxr",
 		"deploy:staging": "wrangler deploy --env staging",
 		"deploy:preview": "wrangler deploy --env preview",

--- a/apps/user-credentials-cache/package.json
+++ b/apps/user-credentials-cache/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "wrangler dev --port 4003 --inspector-port 6003",
 		"deploy:uxr": "wrangler deploy --env uxr",
 		"deploy:staging": "wrangler deploy --env staging",
 		"deploy:preview": "wrangler deploy --env preview",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         version: 2.6.2(@emotion/react@11.14.0(@types/react@18.3.21)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.21)(react@19.1.0))(@types/react@18.3.21)(react@19.1.0))(react@19.1.0)
       '@chakra-ui/theme-tools':
         specifier: ^2.1.2
-        version: 2.2.6(@chakra-ui/styled-system@2.9.2)(react@19.1.0)
+        version: 2.2.6(@chakra-ui/styled-system@2.12.3(react@19.1.0))(react@19.1.0)
       '@emotion/react':
         specifier: ^11.11.4
         version: 11.14.0(@types/react@18.3.21)(react@19.1.0)
@@ -326,9 +326,6 @@ importers:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8.23
         version: 0.8.30(@cloudflare/workers-types@4.20250607.0)(@vitest/runner@3.1.4)(@vitest/snapshot@3.1.4)(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.17.48)(jiti@2.4.2)(terser@5.16.9)(tsx@4.19.4)(yaml@2.8.0))
-      '@cloudflare/workers-types':
-        specifier: ^4.20250525.0
-        version: 4.20250607.0
       '@eslint/compat':
         specifier: ^1.2.8
         version: 1.2.9(eslint@9.27.0(jiti@2.4.2))
@@ -4893,6 +4890,7 @@ packages:
 
   bun@1.2.13:
     resolution: {integrity: sha512-EhP1MhFbicqtaRSFCbEZdkcFco8Ov47cNJcB9QmKS8U4cojKHfLU+dQR14lCvLYmtBvGgwv/Lp+9SSver2OPzQ==}
+    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -11194,10 +11192,10 @@ snapshots:
       '@chakra-ui/styled-system': 2.9.2
       color2k: 2.0.3
 
-  '@chakra-ui/theme-tools@2.2.6(@chakra-ui/styled-system@2.9.2)(react@19.1.0)':
+  '@chakra-ui/theme-tools@2.2.6(@chakra-ui/styled-system@2.12.3(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@chakra-ui/anatomy': 2.3.4
-      '@chakra-ui/styled-system': 2.9.2
+      '@chakra-ui/styled-system': 2.12.3(react@19.1.0)
       '@chakra-ui/utils': 2.2.2(react@19.1.0)
       color2k: 2.0.3
     transitivePeerDependencies:


### PR DESCRIPTION
### TL;DR

Standardized port assignments for all services and added Node inspector ports for debugging.

### What changed?

- Reorganized port assignments for all services to follow a consistent pattern:
  - Application ports now use the 4000-4007 range
  - Inspector ports use the 6000-6007 range
- Updated the README.md with a new service port table that includes inspector ports
- Enhanced the pre-commit hook to abort commits when syncpack modifies package.json files
- Removed unnecessary `@cloudflare/workers-types` dependency from catalyst-ui-worker
- Added Node inspector support for the catalyst-ui-worker

### How to test?

1. Run the local development environment using `./run_local_dev.sh`
2. Verify all services start on their newly assigned ports
3. Test debugging by connecting to the inspector ports (e.g., using Chrome DevTools)
4. Verify the pre-commit hook works by making a change to a package.json file and attempting to commit

### Why make this change?

This change brings consistency to the port assignments across all services, making the development environment more predictable and easier to navigate. The addition of inspector ports enables better debugging capabilities for all services. The pre-commit hook improvement helps maintain package.json consistency by alerting developers when syncpack makes changes that need to be reviewed before committing.