### PR TITLE
feat(data-channel-certifier): implement JWT token validation engine

### DIFF
--- a/apps/data-channel-certifier/src/env.d.ts
+++ b/apps/data-channel-certifier/src/env.d.ts
@@ -1,0 +1,31 @@
+interface Env {
+  // Service bindings
+  AUTHX_TOKEN_API: {
+    signSystemJWT(params: {
+      callingService: string;
+      channelId?: string;
+      channelIds?: string[];
+      purpose: string;
+      duration?: number;
+    }): Promise<{ success: boolean; token?: string; expiration?: number; error?: string }>;
+  };
+
+  DATA_CHANNEL_REGISTRAR: {
+    list(): Promise<Array<{
+      id: string;
+      name: string;
+      endpoint: string;
+      creatorOrganization: string;
+      accessSwitch: boolean;
+      description: string;
+    }> | null>;
+
+    updateAccessSwitch(
+      channelId: string,
+      enabled: boolean
+    ): Promise<{ success: boolean; error?: string }>;
+  };
+
+  // Environment variables
+  ENVIRONMENT?: string;
+}

--- a/apps/data-channel-certifier/src/validation-engine.ts
+++ b/apps/data-channel-certifier/src/validation-engine.ts
@@ -1,0 +1,263 @@
+import { ValidationResult } from './schemas';
+
+/**
+ * Test result for individual validation tests
+ */
+export interface TestResult {
+  testType: 'jwt_validation' | 'introspection' | 'schema_compliance';
+  success: boolean;
+  duration: number;
+  errorDetails?: string;
+}
+
+/**
+ * Validation request for a data channel
+ */
+export interface ValidationRequest {
+  channelId: string;
+  endpoint: string;
+  organizationId: string;
+}
+
+/**
+ * Environment bindings for the validation engine
+ */
+export interface ValidationEnv {
+  AUTHX_TOKEN_API: {
+    signSystemJWT(params: {
+      callingService: string;
+      channelId: string;
+      purpose: string;
+      duration?: number;
+    }): Promise<{ success: boolean; token?: string; expiration?: number; error?: string }>;
+  };
+}
+
+/**
+ * Validation Engine for JWT token validation
+ * Implements the core validation logic for the MVP
+ */
+export class ValidationEngine {
+  constructor(private env: ValidationEnv) {}
+
+  /**
+   * Validates a data channel endpoint with all configured tests
+   * MVP implementation starts with JWT validation, other tests to be added
+   */
+  async validateChannel(request: ValidationRequest): Promise<ValidationResult> {
+    const startTime = Date.now();
+    const tests: TestResult[] = [];
+
+    try {
+      // 1. JWT Validation Test (MVP - Implemented)
+      const jwtTest = await this.testJWTValidation(request);
+      tests.push(jwtTest);
+
+      // Future tests will be added here as needed
+
+      // Determine overall status based on test results
+      const allPassed = tests.every((test) => test.success);
+      const status = allPassed ? 'valid' : 'invalid';
+
+      return {
+        channelId: request.channelId,
+        status,
+        timestamp: Date.now(),
+        details: {
+          endpoint: request.endpoint,
+          organizationId: request.organizationId,
+          duration: Date.now() - startTime,
+          tests: tests,
+          tokenValidation: jwtTest.success,
+          tokenValidationError: jwtTest.errorDetails,
+        },
+      };
+    } catch (error) {
+      // Handle unexpected errors
+      return {
+        channelId: request.channelId,
+        status: 'error',
+        timestamp: Date.now(),
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+        details: {
+          endpoint: request.endpoint,
+          organizationId: request.organizationId,
+          duration: Date.now() - startTime,
+          tests: tests,
+        },
+      };
+    }
+  }
+
+  /**
+   * Tests JWT token validation for a data channel
+   * Validates that the channel accepts valid tokens and rejects invalid ones
+   */
+  private async testJWTValidation(request: ValidationRequest): Promise<TestResult> {
+    const testStart = Date.now();
+
+    try {
+      // Step 1: Request a system JWT token for this channel
+      const tokenResponse = await this.env.AUTHX_TOKEN_API.signSystemJWT({
+        callingService: 'data-channel-certifier',
+        channelId: request.channelId,
+        purpose: 'channel-validation',
+        duration: 300, // 5 minutes
+      });
+
+      if (!tokenResponse.success || !tokenResponse.token) {
+        return {
+          testType: 'jwt_validation',
+          success: false,
+          duration: Date.now() - testStart,
+          errorDetails: tokenResponse.error || 'Failed to obtain validation token',
+        };
+      }
+
+      // Step 2: Test the channel endpoint with the valid token
+      const validTokenTest = await this.testChannelWithToken(
+        request.endpoint,
+        tokenResponse.token,
+        true // expecting success
+      );
+
+      // Step 3: Test the channel endpoint with an invalid token
+      const invalidToken = 'invalid.jwt.token';
+      const invalidTokenTest = await this.testChannelWithToken(
+        request.endpoint,
+        invalidToken,
+        false // expecting rejection
+      );
+
+      // Step 4: Test the channel endpoint with no token
+      const noTokenTest = await this.testChannelWithToken(
+        request.endpoint,
+        '', // empty token
+        false // expecting rejection
+      );
+
+      // All tests must pass for JWT validation to succeed:
+      // - Valid token should be accepted (authenticated)
+      // - Invalid token should be rejected (not authenticated)
+      // - No token should be rejected (not authenticated)
+      const success = validTokenTest.accepted && invalidTokenTest.accepted && noTokenTest.accepted;
+
+      return {
+        testType: 'jwt_validation',
+        success,
+        duration: Date.now() - testStart,
+        errorDetails: success
+          ? undefined
+          : this.formatJWTTestError(validTokenTest, invalidTokenTest, noTokenTest),
+      };
+    } catch (error) {
+      return {
+        testType: 'jwt_validation',
+        success: false,
+        duration: Date.now() - testStart,
+        errorDetails: `JWT validation test failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
+  }
+
+  /**
+   * Tests if a channel endpoint properly validates JWT tokens
+   * Focuses purely on authentication behavior - accepts valid tokens, rejects invalid ones
+   */
+  private async testChannelWithToken(
+    endpoint: string,
+    token: string,
+    expectSuccess: boolean
+  ): Promise<{ accepted: boolean; statusCode?: number; error?: string }> {
+    try {
+      // Simple introspection query to test authentication
+      const query = {
+        query: `{
+          __schema {
+            queryType { name }
+          }
+        }`,
+      };
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+
+      // Only add Authorization header if token is provided
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(query),
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      // For JWT validation, we only care about authentication status
+      const isAuthenticated = response.status !== 401 && response.status !== 403;
+
+      if (expectSuccess) {
+        // Valid token should be authenticated (not 401/403)
+        return {
+          accepted: isAuthenticated,
+          statusCode: response.status,
+          error: isAuthenticated
+            ? undefined
+            : `Valid token rejected with status ${response.status}`,
+        };
+      } else {
+        // Invalid token should NOT be authenticated (should be 401/403)
+        return {
+          accepted: !isAuthenticated,
+          statusCode: response.status,
+          error: !isAuthenticated
+            ? undefined
+            : `Invalid token accepted with status ${response.status}`,
+        };
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return {
+          accepted: false,
+          error: 'Request timeout (10s)',
+        };
+      }
+
+      return {
+        accepted: false,
+        error: `Network error: ${error instanceof Error ? error.message : 'Unknown'}`,
+      };
+    }
+  }
+
+  /**
+   * Formats error message for JWT validation test failures
+   */
+  private formatJWTTestError(
+    validTokenTest: { accepted: boolean; error?: string },
+    invalidTokenTest: { accepted: boolean; error?: string },
+    noTokenTest: { accepted: boolean; error?: string }
+  ): string {
+    const errors: string[] = [];
+
+    if (!validTokenTest.accepted) {
+      errors.push(`Valid token rejected: ${validTokenTest.error || 'Unknown reason'}`);
+    }
+
+    if (!invalidTokenTest.accepted) {
+      errors.push(
+        `Invalid token test failed: ${invalidTokenTest.error || 'Channel did not reject invalid token'}`
+      );
+    }
+
+    if (!noTokenTest.accepted) {
+      errors.push(
+        `No token test failed: ${noTokenTest.error || 'Channel did not reject missing token'}`
+      );
+    }
+
+    return errors.join('; ');
+  }
+}

--- a/apps/data-channel-certifier/src/worker.ts
+++ b/apps/data-channel-certifier/src/worker.ts
@@ -1,4 +1,6 @@
 import { WorkerEntrypoint } from 'cloudflare:workers';
+import { ValidationEngine, ValidationRequest } from './validation-engine';
+import { ValidationResult, ValidationReport } from './schemas';
 
 /**
  * Data Channel Certifier Service
@@ -19,22 +21,124 @@ export default class DataChannelCertifierWorker extends WorkerEntrypoint<Env> {
    * Cron trigger handler - runs validation on schedule
    */
   async scheduled(): Promise<void> {
-    // TODO: Implement scheduled validation
+    console.log('[DataChannelCertifier] Starting scheduled validation run');
+
+    try {
+      // Get all registered data channels from the registrar
+      const channels = await this.env.DATA_CHANNEL_REGISTRAR.list();
+
+      if (!channels || channels.length === 0) {
+        console.log('[DataChannelCertifier] No channels found to validate');
+        return;
+      }
+
+      console.log(`[DataChannelCertifier] Validating ${channels.length} channels`);
+
+      // Validate all channels
+      const results = await this.validateBulkChannels(channels);
+
+      console.log(`[DataChannelCertifier] Validation complete:`, {
+        total: results.totalChannels,
+        valid: results.validChannels,
+        invalid: results.invalidChannels,
+        errors: results.errorChannels,
+      });
+    } catch (error) {
+      console.error('[DataChannelCertifier] Scheduled validation failed:', error);
+    }
   }
 
   /**
    * RPC method: Validate all enabled channels (bulk validation)
    */
-  async validateBulkChannels(): Promise<Record<string, unknown>> {
-    // TODO: Implement bulk validation
-    return {};
+  async validateBulkChannels(
+    channels?: Array<{ id: string; endpoint: string; creatorOrganization: string }>
+  ): Promise<ValidationReport> {
+    const startTime = Date.now();
+    const validationEngine = new ValidationEngine(this.env);
+    const results: ValidationResult[] = [];
+
+    try {
+      // If no channels provided, get from registrar
+      if (!channels) {
+        const registrarChannels = await this.env.DATA_CHANNEL_REGISTRAR.list();
+        channels = registrarChannels || [];
+      }
+
+      // Validate each channel in parallel with controlled concurrency
+      const validationPromises = channels.map(async (channel) => {
+        const request: ValidationRequest = {
+          channelId: channel.id,
+          endpoint: channel.endpoint,
+          organizationId: channel.creatorOrganization,
+        };
+
+        return validationEngine.validateChannel(request);
+      });
+
+      // Use Promise.allSettled to handle partial failures
+      const settledResults = await Promise.allSettled(validationPromises);
+
+      for (const result of settledResults) {
+        if (result.status === 'fulfilled') {
+          results.push(result.value);
+        } else {
+          console.error('[DataChannelCertifier] Channel validation failed:', result.reason);
+        }
+      }
+    } catch (error) {
+      console.error('[DataChannelCertifier] Bulk validation error:', error);
+    }
+
+    // Calculate summary statistics
+    const validChannels = results.filter((r) => r.status === 'valid').length;
+    const invalidChannels = results.filter((r) => r.status === 'invalid').length;
+    const errorChannels = results.filter((r) => r.status === 'error').length;
+
+    return {
+      timestamp: startTime,
+      totalChannels: channels.length,
+      validChannels,
+      invalidChannels,
+      errorChannels,
+      results,
+    };
   }
 
   /**
    * RPC method: Validate a single channel
    */
-  async validateChannel(): Promise<Record<string, unknown>> {
-    // TODO: Implement single channel validation
-    return {};
+  async validateChannel(request: ValidationRequest): Promise<ValidationResult> {
+    const validationEngine = new ValidationEngine(this.env);
+
+    try {
+      // Validate the channel
+      const result = await validationEngine.validateChannel(request);
+
+      // Optionally update the channel status in the registrar
+      // This could be used to disable non-compliant channels
+      if (result.status === 'invalid' || result.status === 'error') {
+        console.warn(
+          `[DataChannelCertifier] Channel ${request.channelId} validation failed:`,
+          result.error || 'Invalid'
+        );
+        // Future: Could update channel access switch here
+        // await this.env.DATA_CHANNEL_REGISTRAR.updateAccessSwitch(request.channelId, false);
+      }
+
+      return result;
+    } catch (error) {
+      console.error(`[DataChannelCertifier] Error validating channel ${request.channelId}:`, error);
+      return {
+        channelId: request.channelId,
+        status: 'error',
+        timestamp: Date.now(),
+        error: error instanceof Error ? error.message : 'Unknown error',
+        details: {
+          endpoint: request.endpoint,
+          organizationId: request.organizationId,
+        },
+      };
+    }
   }
 }

--- a/apps/data-channel-certifier/test/unit/validation-engine.spec.ts
+++ b/apps/data-channel-certifier/test/unit/validation-engine.spec.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValidationEngine, ValidationEnv, ValidationRequest } from '../../src/validation-engine';
+
+describe('ValidationEngine', () => {
+  let validationEngine: ValidationEngine;
+  let mockEnv: ValidationEnv;
+
+  beforeEach(() => {
+    // Mock the AUTHX_TOKEN_API service
+    mockEnv = {
+      AUTHX_TOKEN_API: {
+        signSystemJWT: vi.fn().mockResolvedValue({
+          success: true,
+          token: 'valid.jwt.token',
+          expiration: Date.now() + 300000, // 5 minutes
+        }),
+      },
+    };
+
+    validationEngine = new ValidationEngine(mockEnv);
+  });
+
+  describe('validateChannel', () => {
+    it('should validate a channel with proper JWT authentication behavior', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch:
+      // 1. Valid token - returns 200 (authenticated)
+      // 2. Invalid token - returns 401 (not authenticated)
+      // 3. No token - returns 401 (not authenticated)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 200, // Valid token accepted
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // Invalid token rejected
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // No token rejected
+        } as Response);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'valid',
+        details: expect.objectContaining({
+          endpoint: 'https://example.com/graphql',
+          organizationId: 'test-org-id',
+          tokenValidation: true,
+        }),
+      });
+
+      // Verify all three requests were made
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+
+      // Check that the third call had no Authorization header
+      const thirdCall = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[2];
+      expect(thirdCall[1].headers['Authorization']).toBeUndefined();
+    });
+
+    it('should mark channel as invalid when valid token is rejected', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch:
+      // 1. Valid token - returns 401 (should be accepted but isn't)
+      // 2. Invalid token - returns 401 (correctly rejected)
+      // 3. No token - returns 401 (correctly rejected)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 401, // Valid token incorrectly rejected
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // Invalid token correctly rejected
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // No token correctly rejected
+        } as Response);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Valid token rejected'),
+        }),
+      });
+    });
+
+    it('should mark channel as invalid when invalid token is accepted', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch:
+      // 1. Valid token - returns 200 (correctly accepted)
+      // 2. Invalid token - returns 200 (should be rejected but isn't)
+      // 3. No token - returns 401 (correctly rejected)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 200, // Valid token correctly accepted
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 200, // Invalid token incorrectly accepted
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // No token correctly rejected
+        } as Response);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Invalid token accepted'),
+        }),
+      });
+    });
+
+    it('should mark channel as invalid when no token is accepted', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch:
+      // 1. Valid token - returns 200 (correctly accepted)
+      // 2. Invalid token - returns 401 (correctly rejected)
+      // 3. No token - returns 200 (should be rejected but isn't)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 200, // Valid token correctly accepted
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 401, // Invalid token correctly rejected
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 200, // No token incorrectly accepted
+        } as Response);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('No token test failed'),
+        }),
+      });
+    });
+
+    it('should handle network errors gracefully', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch to throw network error
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Network error'),
+        }),
+      });
+    });
+
+    it('should handle timeout errors', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch to simulate timeout
+      const timeoutError = new Error('Request timeout');
+      timeoutError.name = 'AbortError';
+      global.fetch = vi.fn().mockRejectedValue(timeoutError);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Request timeout'),
+        }),
+      });
+    });
+
+    it('should handle token signing failure', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock token signing failure
+      mockEnv.AUTHX_TOKEN_API.signSystemJWT = vi.fn().mockResolvedValue({
+        success: false,
+        error: 'Failed to sign token',
+      });
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Failed to sign token'),
+        }),
+      });
+    });
+
+    it('should handle both valid and invalid tokens rejected (no proper authentication)', async () => {
+      const request: ValidationRequest = {
+        channelId: 'test-channel-id',
+        endpoint: 'https://example.com/graphql',
+        organizationId: 'test-org-id',
+      };
+
+      // Mock fetch: both tokens get 403 (forbidden)
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 403, // Valid token rejected
+        } as Response)
+        .mockResolvedValueOnce({
+          status: 403, // Invalid token rejected
+        } as Response);
+
+      const result = await validationEngine.validateChannel(request);
+
+      expect(result).toMatchObject({
+        channelId: 'test-channel-id',
+        status: 'invalid',
+        details: expect.objectContaining({
+          tokenValidation: false,
+          tokenValidationError: expect.stringContaining('Valid token rejected'),
+        }),
+      });
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Implemented the validation engine for the data channel certifier service to verify JWT authentication compliance.

### What changed?

- Added a `ValidationEngine` class that tests data channels for proper JWT token handling
- Implemented three key JWT validation tests:
  - Valid tokens should be accepted (200 OK)
  - Invalid tokens should be rejected (401/403)
  - Missing tokens should be rejected (401/403)
- Updated the worker implementation to run validations on both scheduled and on-demand basis
- Added environment type definitions for service bindings
- Created comprehensive unit tests for the validation engine

### How to test?

1. Run the unit tests to verify the validation engine's behavior:
   ```
   pnpm test -- apps/data-channel-certifier/test/unit/validation-engine.spec.ts
   ```
2. Deploy the service and test validation against a real data channel:
   - Use the scheduled cron job to validate all channels - pretty sure this is jacked atm
   - Or manually trigger validation for a specific channel

### Why make this change?

This implementation provides the core functionality for the data channel certification service, allowing us to automatically verify that data channels properly implement JWT authentication. This ensures that all channels in the ecosystem maintain a consistent security posture by correctly validating access tokens before allowing data access.