### PR TITLE
feat(data-channel-certifier): add basic data channel val ui integration

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/validation.ts
+++ b/apps/catalyst-ui-worker/app/actions/validation.ts
@@ -1,0 +1,32 @@
+'use server';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { ValidationResult } from '@catalyst/schema_zod';
+
+function getEnv() {
+    return getCloudflareContext().env as CloudflareEnv;
+}
+
+function getCertifier() {
+    // Service binding to data-channel-certifier
+    return getEnv().DATA_CHANNEL_CERTIFIER;
+}
+
+export async function validateChannel(channelId: string, endpoint: string, organization: string) {
+    const certifier = getCertifier();
+
+    try {
+        // Call the RPC method directly via service binding
+        const result = await certifier.validateChannel({
+            channelId,
+            endpoint,
+            organizationId: organization,
+        });
+
+        // Ensure it's a plain object by converting to JSON and back
+        // This removes any class instances or non-serializable data
+        return JSON.parse(JSON.stringify(result)) as ValidationResult;
+    } catch (error) {
+        console.error('Failed to validate channel:', error);
+        throw new Error('Failed to validate data channel');
+    }
+}

--- a/apps/catalyst-ui-worker/components/channels/ListChannels.tsx
+++ b/apps/catalyst-ui-worker/components/channels/ListChannels.tsx
@@ -8,6 +8,7 @@ import {
     OrbisButton,
     OrbisTable,
 } from '@/components/elements';
+import { ValidationButton } from './ValidationStatus';
 import { ListView } from '@/components/layouts';
 import { navigationItems } from '@/utils/nav.utils';
 import { DataChannel } from '@catalyst/schema_zod';
@@ -184,7 +185,7 @@ export default function DataChannelListComponents({ listChannels, deleteChannel 
                             ) : channels.length > 0 ? (
                                 <Card>
                                     <OrbisTable
-                                        headers={['Data Channel', 'Description', 'Channel ID', '']}
+                                        headers={['Data Channel', 'Description', 'Channel ID', 'Validation', '']}
                                         rows={channels.map((channel, index) => {
                                             return [
                                                 <Flex
@@ -211,6 +212,12 @@ export default function DataChannelListComponents({ listChannels, deleteChannel 
                                                 <APIKeyText allowCopy showAsClearText key={index + '-channel-id'}>
                                                     {channel.id}
                                                 </APIKeyText>,
+                                                <ValidationButton
+                                                    key={index + '-validation'}
+                                                    channelId={channel.id}
+                                                    endpoint={channel.endpoint}
+                                                    organizationId={channel.creatorOrganization}
+                                                />,
                                                 <Menu key={index + '-menu'}>
                                                     <MenuButton
                                                         as={IconButton}
@@ -220,7 +227,7 @@ export default function DataChannelListComponents({ listChannels, deleteChannel 
                                                         aria-label="Channel options"
                                                     />
                                                     <MenuList>
-                                                        {channel.creatorOrganization === user?.custom.org && (
+                                                        {channel.creatorOrganization === user?.custom.org ? (
                                                             <MenuItem
                                                                 icon={<TrashIcon width={16} height={16} />}
                                                                 color="red.500"
@@ -228,6 +235,8 @@ export default function DataChannelListComponents({ listChannels, deleteChannel 
                                                             >
                                                                 Delete Channel
                                                             </MenuItem>
+                                                        ) : (
+                                                            <MenuItem isDisabled>No actions available</MenuItem>
                                                         )}
                                                     </MenuList>
                                                 </Menu>,

--- a/apps/catalyst-ui-worker/components/channels/ValidationStatus.tsx
+++ b/apps/catalyst-ui-worker/components/channels/ValidationStatus.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { Badge, Button, Spinner, Tooltip } from '@chakra-ui/react';
+import { CheckCircleIcon, XCircleIcon, ExclamationCircleIcon, ClockIcon } from '@heroicons/react/20/solid';
+import { useState } from 'react';
+import { validateChannel } from '@/app/actions/validation';
+
+interface ValidationStatusProps {
+    channelId: string;
+    endpoint: string;
+    organizationId: string;
+    lastValidation?: {
+        status: 'valid' | 'invalid' | 'error';
+        timestamp: number;
+        error?: string;
+    };
+}
+
+export function ValidationStatusBadge({ status }: { status?: 'valid' | 'invalid' | 'error' | 'pending' }) {
+    if (!status) {
+        return (
+            <Badge colorScheme="gray" display="flex" alignItems="center" gap={1}>
+                <ClockIcon width={12} height={12} />
+                Never Validated
+            </Badge>
+        );
+    }
+
+    const configs = {
+        valid: {
+            color: 'green',
+            icon: <CheckCircleIcon width={12} height={12} />,
+            label: 'Valid',
+        },
+        invalid: {
+            color: 'red',
+            icon: <XCircleIcon width={12} height={12} />,
+            label: 'Invalid',
+        },
+        error: {
+            color: 'orange',
+            icon: <ExclamationCircleIcon width={12} height={12} />,
+            label: 'Error',
+        },
+        pending: {
+            color: 'blue',
+            icon: <Spinner size="xs" />,
+            label: 'Validating',
+        },
+    };
+
+    const config = configs[status];
+
+    return (
+        <Badge colorScheme={config.color} display="flex" alignItems="center" gap={1}>
+            {config.icon}
+            {config.label}
+        </Badge>
+    );
+}
+
+export function ValidationButton({
+    channelId,
+    endpoint,
+    organizationId,
+}: Omit<ValidationStatusProps, 'lastValidation'>) {
+    const [isValidating, setIsValidating] = useState(false);
+    const [validationStatus, setValidationStatus] = useState<'valid' | 'invalid' | 'error' | undefined>();
+    const [lastError, setLastError] = useState<string>();
+
+    const handleValidate = async () => {
+        setIsValidating(true);
+        setValidationStatus(undefined);
+        setLastError(undefined);
+
+        try {
+            const result = await validateChannel(channelId, endpoint, organizationId);
+
+            // Map the result status to our badge status
+            if (result.status === 'valid') {
+                setValidationStatus('valid');
+            } else if (result.status === 'invalid') {
+                setValidationStatus('invalid');
+                setLastError(result.error || 'Validation failed');
+            } else {
+                setValidationStatus('error');
+                setLastError(result.error || 'Unknown error');
+            }
+        } catch (error) {
+            console.error('Validation error:', error);
+            setValidationStatus('error');
+            setLastError('Failed to run validation');
+        } finally {
+            setIsValidating(false);
+        }
+    };
+
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {validationStatus && (
+                <Tooltip label={lastError} isDisabled={!lastError}>
+                    <div>
+                        <ValidationStatusBadge status={validationStatus} />
+                    </div>
+                </Tooltip>
+            )}
+            <Button
+                size="sm"
+                colorScheme="blue"
+                variant="outline"
+                onClick={handleValidate}
+                isLoading={isValidating}
+                loadingText="Validating..."
+            >
+                Validate
+            </Button>
+        </div>
+    );
+}

--- a/apps/catalyst-ui-worker/env.d.ts
+++ b/apps/catalyst-ui-worker/env.d.ts
@@ -4,6 +4,7 @@ import AuthzedWorker from '../authx_authzed_api/src';
 import UserCredsCacheWorker from '../user-credentials-cache/src';
 import OrganizationMatchmakingWorker from '../organization_matchmaking/src';
 import IssuedJWTRegistryWorker from '@catalyst/issued-jwt-registry/src';
+import DataChannelCertifierWorker from '../data-channel-certifier/src/worker';
 
 declare global {
     interface CloudflareEnv {
@@ -13,6 +14,7 @@ declare global {
         USER_CREDS_CACHE: Service<UserCredsCacheWorker>;
         ORGANIZATION_MATCHMAKING: Service<OrganizationMatchmakingWorker>;
         ISSUED_JWT_WORKER: Service<IssuedJWTRegistryWorker>;
+        DATA_CHANNEL_CERTIFIER: Service<DataChannelCertifierWorker>;
     }
 }
 

--- a/apps/catalyst-ui-worker/wrangler.jsonc
+++ b/apps/catalyst-ui-worker/wrangler.jsonc
@@ -42,6 +42,10 @@
             "binding": "ORGANIZATION_MATCHMAKING",
             "service": "organization-matchmaking",
         },
+        {
+            "binding": "DATA_CHANNEL_CERTIFIER",
+            "service": "data-channel-certifier",
+        },
     ],
     "env": {
         "preview": {
@@ -80,6 +84,10 @@
                     "binding": "ORGANIZATION_MATCHMAKING",
                     "service": "organization-matchmaking-preview",
                 },
+                {
+                    "binding": "DATA_CHANNEL_CERTIFIER",
+                    "service": "data-channel-certifier-preview",
+                },
             ],
         },
         "staging": {
@@ -106,6 +114,7 @@
                 { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-staging" },
                 { "binding": "USER_CREDS_CACHE", "service": "user-credentials-cache-staging" },
                 { "binding": "ORGANIZATION_MATCHMAKING", "service": "organization-matchmaking-staging" },
+                { "binding": "DATA_CHANNEL_CERTIFIER", "service": "data-channel-certifier-staging" },
             ],
         },
         // "demo": {
@@ -165,6 +174,10 @@
                     "binding": "ORGANIZATION_MATCHMAKING",
                     "service": "organization-matchmaking-uxr",
                 },
+                {
+                    "binding": "DATA_CHANNEL_CERTIFIER",
+                    "service": "data-channel-certifier-uxr",
+                },
             ],
         },
         "production": {
@@ -188,6 +201,7 @@
                 { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-production" },
                 { "binding": "USER_CREDS_CACHE", "service": "user-credentials-cache-production" },
                 { "binding": "ORGANIZATION_MATCHMAKING", "service": "organization-matchmaking-production" },
+                { "binding": "DATA_CHANNEL_CERTIFIER", "service": "data-channel-certifier-production" },
             ],
         },
     },


### PR DESCRIPTION
### TL;DR

Added data channel validation functionality to the UI, allowing users to verify if their data channels are properly configured.

### What changed?

- Created a new server action `validateChannel` that communicates with the data-channel-certifier service
- Added a validation button to the data channels list that allows users to check channel validity
- Implemented a validation status badge that displays the result (valid, invalid, or error)
- Added tooltips to show validation error details when hovering over invalid status badges
- Updated the data channel table to include a validation column
- Added the DATA_CHANNEL_CERTIFIER service binding to all environments in wrangler.jsonc

### How to test?

1. Navigate to the data channels list in the UI
2. For any data channel, click the "Validate" button
3. Observe the validation status badge that appears (valid, invalid, or error)
4. If validation fails, hover over the badge to see the error details

### Why make this change?

This feature helps users verify that their data channels are correctly configured and accessible. It provides immediate feedback on channel validity, making it easier to troubleshoot configuration issues without having to check logs or perform manual testing.