### PR TITLE
refactor: centralize service binding access pattern

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/channels.ts
+++ b/apps/catalyst-ui-worker/app/actions/channels.ts
@@ -1,18 +1,15 @@
 'use server';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { DataChannel } from '@catalyst/schema_zod';
-import RegistrarWorker from '@catalyst/data_channel_registrar/src/worker';
+import { CloudflareEnv, getRegistrar } from '@catalyst/schemas';
 
-function getEnv() {
+function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
 }
 
-function getRegistar() {
-    return getEnv().CATALYST_DATA_CHANNEL_REGISTRAR_API as Service<RegistrarWorker>;
-}
-
 export async function createDataChannel(formData: FormData, token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
     const tokenObject = {
         cfToken: token,
     };
@@ -40,7 +37,8 @@ export async function createDataChannel(formData: FormData, token: string) {
 }
 
 export async function listChannels(token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
 
     const tokenObject = {
         cfToken: token,
@@ -59,7 +57,8 @@ export async function listPartnersChannels(token: string, partnerId: string) {
 }
 
 export async function getChannel(channelId: string, token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
     const tokenObject = {
         cfToken: token,
     };
@@ -72,7 +71,8 @@ export async function getChannel(channelId: string, token: string) {
 }
 
 export async function updateChannel(formData: FormData, token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
     const tokenObject = {
         cfToken: token,
     };
@@ -98,7 +98,8 @@ export async function updateChannel(formData: FormData, token: string) {
 }
 
 export async function handleSwitch(channelId: string, accessSwitch: boolean, token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
     const tokenObject = {
         cfToken: token,
     };
@@ -116,7 +117,8 @@ export async function handleSwitch(channelId: string, accessSwitch: boolean, tok
 }
 
 export async function deleteChannel(channelID: string, token: string) {
-    const api = getRegistar();
+    const env = getEnv();
+    const api = getRegistrar(env);
     const tokenObject = {
         cfToken: token,
     };

--- a/apps/catalyst-ui-worker/app/actions/i-jwt-registry.ts
+++ b/apps/catalyst-ui-worker/app/actions/i-jwt-registry.ts
@@ -1,17 +1,16 @@
 'use server';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { IssuedJWTRegistry } from '@catalyst/schema_zod';
-import IssuedJWTRegistryWorker from '@catalyst/issued-jwt-registry/src';
-function getEnv() {
+import { CloudflareEnv, getJWTRegistry } from '@catalyst/schemas';
+
+function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
-}
-function getIJWT() {
-    return getEnv().ISSUED_JWT_WORKER as Service<IssuedJWTRegistryWorker>;
 }
 
 export async function listIJWTRegistry(token: string) {
-    const matcher = getIJWT();
-    const resp = await matcher.list({ cfToken: token });
+    const env = getEnv();
+    const registry = getJWTRegistry(env);
+    const resp = await registry.list({ cfToken: token });
     if (!resp.success) {
         throw new Error('list ijwt registry failed');
     }
@@ -19,8 +18,9 @@ export async function listIJWTRegistry(token: string) {
 }
 
 export async function getIJWTRegistry(token: string, id: string) {
-    const matcher = getIJWT();
-    const getResult = await matcher.get({ cfToken: token }, id);
+    const env = getEnv();
+    const registry = getJWTRegistry(env);
+    const getResult = await registry.get({ cfToken: token }, id);
     if (!getResult.success) {
         throw new Error('get ijwt registry failed');
     }
@@ -28,8 +28,9 @@ export async function getIJWTRegistry(token: string, id: string) {
 }
 
 export async function createIJWTRegistry(token: string, data: Omit<IssuedJWTRegistry, 'id'>) {
-    const matcher = getIJWT();
-    const resp = await matcher.create({ cfToken: token }, data);
+    const env = getEnv();
+    const registry = getJWTRegistry(env);
+    const resp = await registry.create({ cfToken: token }, data);
     if (!resp.success) {
         throw new Error('create ijwt registry failed');
     }
@@ -37,8 +38,9 @@ export async function createIJWTRegistry(token: string, data: Omit<IssuedJWTRegi
 }
 
 export async function updateIJWTRegistry(token: string, data: IssuedJWTRegistry) {
-    const matcher = getIJWT();
-    const resp = await matcher.update({ cfToken: token }, data);
+    const env = getEnv();
+    const registry = getJWTRegistry(env);
+    const resp = await registry.update({ cfToken: token }, data);
     if (!resp.success) {
         throw new Error('update ijwt registry failed');
     }
@@ -46,8 +48,9 @@ export async function updateIJWTRegistry(token: string, data: IssuedJWTRegistry)
 }
 
 export async function deleteIJWTRegistry(token: string, id: string) {
-    const matcher = getIJWT();
-    const resp = await matcher.delete({ cfToken: token }, id);
+    const env = getEnv();
+    const registry = getJWTRegistry(env);
+    const resp = await registry.delete({ cfToken: token }, id);
     if (!resp) {
         throw new Error('delete ijwt registry failed');
     }

--- a/apps/catalyst-ui-worker/app/actions/partners.ts
+++ b/apps/catalyst-ui-worker/app/actions/partners.ts
@@ -1,18 +1,15 @@
 'use server';
 import { OrgInvite } from '@catalyst/schema_zod';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
-import OrganizationMatchmakingWorker from '@catalyst/organization-matchmaking/src';
+import { CloudflareEnv, getMatchmaking } from '@catalyst/schemas';
 
-function getEnv() {
+function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
 }
 
-function getMatcher() {
-    return getEnv().ORGANIZATION_MATCHMAKING as Service<OrganizationMatchmakingWorker>;
-}
-
 export async function listInvites(token: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     const result = await matcher.listInvites({ cfToken: token });
     if (!result.success) {
         throw new Error(result.error);
@@ -21,7 +18,8 @@ export async function listInvites(token: string) {
 }
 
 export async function sendInvite(receivingOrg: string, token: string, message: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     const result = await matcher.sendInvite(receivingOrg, { cfToken: token }, message);
     if (!result.success) {
         throw new Error('Sending Invite Failed');
@@ -30,7 +28,8 @@ export async function sendInvite(receivingOrg: string, token: string, message: s
 }
 
 export async function readInvite(inviteId: string, token: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     const result = await matcher.readInvite(inviteId, { cfToken: token });
     if (!result.success) {
         throw new Error('Reading Invite Failed');
@@ -39,7 +38,8 @@ export async function readInvite(inviteId: string, token: string) {
 }
 
 export async function declineInvite(inviteId: string, token: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     console.log({ inviteId, token });
     const result = await matcher.declineInvite(inviteId, { cfToken: token });
     if (!result.success) {
@@ -49,7 +49,8 @@ export async function declineInvite(inviteId: string, token: string) {
 }
 
 export async function acceptInvite(inviteId: string, token: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     const result = await matcher.acceptInvite(inviteId, { cfToken: token });
 
     if (!result.success) {
@@ -59,7 +60,8 @@ export async function acceptInvite(inviteId: string, token: string) {
 }
 
 export async function togglePartnership(orgId: string, token: string) {
-    const matcher = getMatcher();
+    const env = getEnv();
+    const matcher = getMatchmaking(env);
     const result = await matcher.togglePartnership(orgId, { cfToken: token });
     if (!result.success) {
         throw new Error('Toggling Partnership Failed');

--- a/apps/catalyst-ui-worker/app/actions/tokens.ts
+++ b/apps/catalyst-ui-worker/app/actions/tokens.ts
@@ -1,16 +1,14 @@
 'use server';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { JWTRequest } from '../types';
-import { DEFAULT_STANDARD_DURATIONS } from '@catalyst/schema_zod';
-import AuthxTokenApiWorker from '@catalyst/authx_token_api/src';
-function getEnv() {
+import { DEFAULT_STANDARD_DURATIONS, CloudflareEnv, getTokenAPI } from '@catalyst/schemas';
+
+function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
 }
-function getAuthx() {
-    return getEnv().AUTHX_TOKEN_API as Service<AuthxTokenApiWorker>;
-}
 export async function getPublicKey() {
-    const tokens = getAuthx();
+    const env = getEnv();
+    const tokens = getTokenAPI(env);
 
     return await tokens.getPublicKey();
 }
@@ -19,10 +17,11 @@ export async function getPublicKey() {
  * WARNING - below is an admin function and will invalidate all active tokens
  */
 export async function rotateJWTKeyMaterial(cfToken: string) {
+    const env = getEnv();
     const tokenObject = {
         cfToken: cfToken,
     };
-    const tokens = getAuthx();
+    const tokens = getTokenAPI(env);
 
     return await tokens.rotateKey(tokenObject);
 }
@@ -38,10 +37,11 @@ export async function signJWT(
     },
     cfToken: string
 ) {
+    const env = getEnv();
     const tokenObject = {
         cfToken: cfToken,
     };
-    const tokens = getAuthx();
+    const tokens = getTokenAPI(env);
     if (expiration.unit === 'days' && expiration.value > 365) {
         throw new Error('Expiration time cannot be greater than 365 days');
     }

--- a/apps/catalyst-ui-worker/app/api/v1/jwt/jwk/route.ts
+++ b/apps/catalyst-ui-worker/app/api/v1/jwt/jwk/route.ts
@@ -1,18 +1,16 @@
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextRequest } from 'next/server';
 export const dynamic = 'force-dynamic'; // defaults to auto
-import AuthxTokenApiWorker from '@catalyst/authx_token_api/src';
-function getEnv() {
-    return getCloudflareContext().env as CloudflareEnv;
-}
+import { CloudflareEnv, getTokenAPI } from '@catalyst/schemas';
 
-function getAuthx() {
-    return getEnv().AUTHX_TOKEN_API as Service<AuthxTokenApiWorker>;
+function getEnv(): CloudflareEnv {
+    return getCloudflareContext().env as CloudflareEnv;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function GET(request: NextRequest) {
-    const tokenAPI = getAuthx();
+    const env = getEnv();
+    const tokenAPI = getTokenAPI(env);
     const jwk = await tokenAPI.getPublicKeyJWK();
     return Response.json(jwk);
 }

--- a/apps/catalyst-ui-worker/app/api/v1/jwt/pubkey/route.ts
+++ b/apps/catalyst-ui-worker/app/api/v1/jwt/pubkey/route.ts
@@ -1,18 +1,16 @@
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextRequest } from 'next/server';
 export const dynamic = 'force-dynamic'; // defaults to auto
-import AuthxTokenApiWorker from '@catalyst/authx_token_api/src';
-function getEnv() {
-    return getCloudflareContext().env as CloudflareEnv;
-}
+import { CloudflareEnv, getTokenAPI } from '@catalyst/schemas';
 
-function getAuthx() {
-    return getEnv().AUTHX_TOKEN_API as Service<AuthxTokenApiWorker>;
+function getEnv(): CloudflareEnv {
+    return getCloudflareContext().env as CloudflareEnv;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function GET(request: NextRequest) {
-    const tokenAPI = getAuthx();
+    const env = getEnv();
+    const tokenAPI = getTokenAPI(env);
 
     const publicKey: { pem: string } = await tokenAPI.getPublicKey();
     return Response.json(publicKey);

--- a/apps/catalyst-ui-worker/app/api/v1/user/sync/route.ts
+++ b/apps/catalyst-ui-worker/app/api/v1/user/sync/route.ts
@@ -2,18 +2,10 @@ import type { User } from '@catalyst/schema_zod/entities/user';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextRequest } from 'next/server';
 export const dynamic = 'force-dynamic'; // defaults to auto
-import UserCredentialsCacheWorker from '@catalyst/user-credentials-cache/src';
-import AuthxAuthzedApiWorker from '@catalyst/authx_authzed_api/src';
-function getEnv() {
+import { CloudflareEnv, getUserCache, getAuthzed } from '@catalyst/schemas';
+
+function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
-}
-
-function getUserCache() {
-    return getEnv().USER_CREDS_CACHE as Service<UserCredentialsCacheWorker>;
-}
-
-function getAuthxAuthzed() {
-    return getEnv().AUTHX_AUTHZED_API as Service<AuthxAuthzedApiWorker>;
 }
 
 export async function GET(request: NextRequest) {
@@ -21,8 +13,9 @@ export async function GET(request: NextRequest) {
     const cfToken = request.cookies.get('CF_Authorization')?.value;
     if (cfToken) {
         // validate CF token
-        const user_cache = getUserCache();
-        const authxAuthzed = getAuthxAuthzed();
+        const env = getEnv();
+        const user_cache = getUserCache(env);
+        const authxAuthzed = getAuthzed(env);
         const user: User | undefined = (await user_cache.getUser(cfToken)) as User | undefined;
         if (user) {
             // user role

--- a/apps/catalyst-ui-worker/app/graphql/route.ts
+++ b/apps/catalyst-ui-worker/app/graphql/route.ts
@@ -1,17 +1,15 @@
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { NextRequest, NextResponse } from 'next/server';
-import DataChannelRegistrarWorker from '@catalyst/data_channel_registrar/src/worker';
-function getEnv() {
-    return getCloudflareContext().env as CloudflareEnv;
-}
+import { CloudflareEnv, getRegistrar } from '@catalyst/schemas';
 
-function getDataChannelRegistrar() {
-    return getEnv().CATALYST_DATA_CHANNEL_REGISTRAR_API as Service<DataChannelRegistrarWorker>;
+function getEnv(): CloudflareEnv {
+    return getCloudflareContext().env as CloudflareEnv;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function POST(req: NextRequest) {
-    const dataChannelRegistrar = getDataChannelRegistrar();
+    const env = getEnv();
+    const dataChannelRegistrar = getRegistrar(env);
     try {
         // Setting cfToken to undefined to avoid the error, was not originally provided
         const data = await dataChannelRegistrar.list('default', { cfToken: undefined });

--- a/apps/data-channel-certifier/package.json
+++ b/apps/data-channel-certifier/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
+    "build": "wrangler build",
     "deploy": "wrangler deploy",
     "deploy:preview": "wrangler deploy --env preview",
     "deploy:staging": "wrangler deploy --env staging",

--- a/packages/schemas/src/core/env.ts
+++ b/packages/schemas/src/core/env.ts
@@ -1,0 +1,53 @@
+/**
+ * Generic service binding type
+ * Represents a Cloudflare Worker service binding accessible via RPC
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface Service<T = unknown> {
+    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+    // RPC methods are accessed directly on the service instance
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+}
+
+// Worker type imports are handled at consumer level to avoid circular dependencies
+// Consumers should cast their env properly or use the helper functions
+
+/**
+ * Centralized Cloudflare Environment interface
+ *
+ * Defines all service bindings available across the Catalyst platform.
+ * Service bindings use RPC pattern via Service<T>, not HTTP fetch.
+ */
+export interface CloudflareEnv {
+    // Service Bindings (RPC) - using unknown to avoid circular dependencies
+    // Actual types are enforced by the service helper functions
+    AUTHX_AUTHZED_API: Service<unknown>;
+    AUTHX_TOKEN_API: Service<unknown>;
+    USER_CREDS_CACHE: Service<unknown>;
+    ISSUED_JWT_WORKER: Service<unknown>;
+    CATALYST_DATA_CHANNEL_REGISTRAR_API: Service<unknown>;
+    DATA_CHANNEL_CERTIFIER: Service<unknown>;
+    ORGANIZATION_MATCHMAKING: Service<unknown>;
+
+    // Self-reference (for recursive calls)
+    WORKER_SELF_REFERENCE?: Service<unknown>;
+
+    // Durable Objects
+    ISSUED_JWT_REGISTRY_DO?: unknown; // DurableObjectNamespace
+
+    // Assets (for UI worker)
+    ASSETS?: unknown; // Fetcher
+}
+
+/**
+ * Type-safe service names
+ */
+export type ServiceName =
+    | 'AUTHX_AUTHZED_API'
+    | 'AUTHX_TOKEN_API'
+    | 'USER_CREDS_CACHE'
+    | 'ISSUED_JWT_WORKER'
+    | 'CATALYST_DATA_CHANNEL_REGISTRAR_API'
+    | 'DATA_CHANNEL_CERTIFIER'
+    | 'ORGANIZATION_MATCHMAKING';

--- a/packages/schemas/src/core/index.ts
+++ b/packages/schemas/src/core/index.ts
@@ -4,3 +4,7 @@ export * from './common';
 export * from './security';
 export * from './composition';
 export * from './performance';
+
+// Export Cloudflare environment and service utilities
+export * from './env';
+export * from './services';

--- a/packages/schemas/src/core/services.ts
+++ b/packages/schemas/src/core/services.ts
@@ -1,0 +1,90 @@
+import type { CloudflareEnv, ServiceName, Service } from './env';
+
+/**
+ * Generic worker interface for service bindings
+ * Allows calling any method without strict typing
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface WorkerService extends Service<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+}
+
+/**
+ * Get a service binding from the Cloudflare environment
+ *
+ * @example
+ * ```typescript
+ * const authzed = getAuthzed(env);
+ * await authzed.checkPermission(...); // Works with any method
+ * ```
+ *
+ * @param env - Cloudflare environment object
+ * @param serviceName - Name of the service binding
+ * @returns Service instance with callable methods
+ */
+export function getService(env: CloudflareEnv, serviceName: ServiceName): WorkerService {
+    const service = env[serviceName];
+
+    if (!service) {
+        throw new Error(`Service binding "${serviceName}" not found in environment`);
+    }
+
+    return service as WorkerService;
+}
+
+/**
+ * Helper to get Authzed service
+ * Returns the AUTHX_AUTHZED_API service binding
+ */
+export function getAuthzed(env: CloudflareEnv): WorkerService {
+    return getService(env, 'AUTHX_AUTHZED_API');
+}
+
+/**
+ * Helper to get Token API service
+ * Returns the AUTHX_TOKEN_API service binding
+ */
+export function getTokenAPI(env: CloudflareEnv): WorkerService {
+    return getService(env, 'AUTHX_TOKEN_API');
+}
+
+/**
+ * Helper to get User Credentials Cache service
+ * Returns the USER_CREDS_CACHE service binding
+ */
+export function getUserCache(env: CloudflareEnv): WorkerService {
+    return getService(env, 'USER_CREDS_CACHE');
+}
+
+/**
+ * Helper to get Issued JWT Registry service
+ * Returns the ISSUED_JWT_WORKER service binding
+ */
+export function getJWTRegistry(env: CloudflareEnv): WorkerService {
+    return getService(env, 'ISSUED_JWT_WORKER');
+}
+
+/**
+ * Helper to get Data Channel Registrar service
+ * Returns the CATALYST_DATA_CHANNEL_REGISTRAR_API service binding
+ */
+export function getRegistrar(env: CloudflareEnv): WorkerService {
+    return getService(env, 'CATALYST_DATA_CHANNEL_REGISTRAR_API');
+}
+
+/**
+ * Helper to get Data Channel Certifier service
+ * Returns the DATA_CHANNEL_CERTIFIER service binding
+ */
+export function getCertifier(env: CloudflareEnv): WorkerService {
+    return getService(env, 'DATA_CHANNEL_CERTIFIER');
+}
+
+/**
+ * Helper to get Organization Matchmaking service
+ * Returns the ORGANIZATION_MATCHMAKING service binding
+ */
+export function getMatchmaking(env: CloudflareEnv): WorkerService {
+    return getService(env, 'ORGANIZATION_MATCHMAKING');
+}


### PR DESCRIPTION
Move service accessor functions to @catalyst/schemas for better
  type safety and reduced boilerplate across catalyst-ui-worker