### PR TITLE
feat: all apps use consistent ISSUED_JWT_REGISTRY binding name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ web_modules/
 
 \*.tsbuildinfo
 
+*.tsbuildinfo
 # Optional npm cache directory
 
 .npm

--- a/apps/authx_token_api/src/env.d.ts
+++ b/apps/authx_token_api/src/env.d.ts
@@ -2,6 +2,6 @@ export interface Env {
 	KEY_PROVIDER: DurableObjectNamespace<import('./durable_object_security_module').JWTKeyProvider>;
 	AUTHZED: Service<import('../../authx_authzed_api/src/index').default>;
 	USERCACHE: Service<import('../../user-credentials-cache/src/index').default>;
-	ISSUED_JWT_REGISTRY_WORKER: Service<import('../../issued-jwt-registry/src/index').default>;
+	ISSUED_JWT_REGISTRY: Service<import('../../issued-jwt-registry/src/index').default>;
 	DATA_CHANNEL_REGISTRAR: Service<import('../../data_channel_registrar/src/worker').default>;
 }

--- a/apps/authx_token_api/wrangler.jsonc
+++ b/apps/authx_token_api/wrangler.jsonc
@@ -19,6 +19,7 @@
 		{ "binding": "AUTHZED", "service": "authx_authzed_api" },
 		{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar" },
 		{ "binding": "USERCACHE", "service": "user-credentials-cache" },
+		{ "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry" },
 	],
 
 	// Durable Objects
@@ -42,6 +43,7 @@
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-preview" },
 				{ "binding": "USERCACHE", "service": "user-credentials-cache-preview" },
 				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-preview" },
+				{ "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry-preview" },
 			],
 			"durable_objects": {
 				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
@@ -52,6 +54,7 @@
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-staging" },
 				{ "binding": "USERCACHE", "service": "user-credentials-cache-staging" },
 				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-staging" },
+				{ "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry-staging" },
 			],
 			"durable_objects": {
 				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
@@ -72,6 +75,7 @@
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-uxr" },
 				{ "binding": "USERCACHE", "service": "user-credentials-cache-uxr" },
 				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-uxr" },
+				{ "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry-uxr" },
 			],
 			"durable_objects": {
 				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],
@@ -82,6 +86,7 @@
 				{ "binding": "AUTHZED", "service": "authx_authzed_api-production" },
 				{ "binding": "USERCACHE", "service": "user-credentials-cache-production" },
 				{ "binding": "DATA_CHANNEL_REGISTRAR", "service": "data_channel_registrar-production" },
+				{ "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry-production" },
 			],
 			"durable_objects": {
 				"bindings": [{ "name": "KEY_PROVIDER", "class_name": "JWTKeyProvider" }],

--- a/apps/catalyst-ui-worker/README.md
+++ b/apps/catalyst-ui-worker/README.md
@@ -17,7 +17,7 @@ This application is built with:
 
 The UI Worker integrates with multiple Catalyst services:
 
-- **ISSUED_JWT_WORKER** - JWT token management
+- **ISSUED_JWT_REGISTRY** - JWT token management
 - **CATALYST_DATA_CHANNEL_REGISTRAR_API** - Data channel discovery and registration
 - **AUTHX_TOKEN_API** - Authentication token services
 - **AUTHX_AUTHZED_API** - Authorization and permissions

--- a/apps/catalyst-ui-worker/cloudflare-env.d.ts
+++ b/apps/catalyst-ui-worker/cloudflare-env.d.ts
@@ -4,7 +4,7 @@
 declare namespace Cloudflare {
     interface Env {
         WORKER_SELF_REFERENCE: Fetcher /* catalyst-ui-worker */;
-        ISSUED_JWT_WORKER: Fetcher /* issued-jwt-registry */;
+        ISSUED_JWT_REGISTRY: Fetcher /* issued-jwt-registry */;
         CATALYST_DATA_CHANNEL_REGISTRAR_API: Fetcher /* data_channel_registrar */;
         AUTHX_TOKEN_API: Fetcher /* authx_token_api */;
         AUTHX_AUTHZED_API: Fetcher /* authx_authzed_api */;
@@ -4107,7 +4107,7 @@ type AIGatewayHeaders = {
     [key: string]: string | number | boolean | object;
 };
 type AIGatewayUniversalRequest = {
-    provider: AIGatewayProviders | string;  
+    provider: AIGatewayProviders | string;
     endpoint: string;
     headers: Partial<AIGatewayHeaders>;
     query: unknown;
@@ -4124,7 +4124,7 @@ declare abstract class AiGateway {
             extraHeaders?: object;
         }
     ): Promise<Response>;
-    getUrl(provider?: AIGatewayProviders | string): Promise<string>;  
+    getUrl(provider?: AIGatewayProviders | string): Promise<string>;
 }
 interface AutoRAGInternalError extends Error {}
 interface AutoRAGNotFoundError extends Error {}

--- a/apps/catalyst-ui-worker/tests/env.d.ts
+++ b/apps/catalyst-ui-worker/tests/env.d.ts
@@ -3,7 +3,7 @@ import { OrganizationMatchmakingDO } from '../../organization_matchmaking/src';
 declare module 'cloudflare:test' {
     // Controls the type of `import("cloudflare:test").env
     interface ProvidedEnv extends Env {
-        ISSUED_JWT_WORKER: Service<IssuedJWTRegistryWorker>;
+        ISSUED_JWT_REGISTRY: Service<IssuedJWTRegistryWorker>;
         ORG_MATCHMAKING: DurableObjectNamespace<OrganizationMatchmakingDO>;
     }
 }

--- a/apps/catalyst-ui-worker/tests/issued_jwt_registry.spec.ts
+++ b/apps/catalyst-ui-worker/tests/issued_jwt_registry.spec.ts
@@ -14,7 +14,7 @@ describe('issued-jwt-registry unit tests', () => {
             organization: 'orbis_operations',
         };
 
-        const savedIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR);
+        const savedIJR = await env.ISSUED_JWT_REGISTRY.create('orbis_operations', newIJR);
 
         expect(savedIJR.id).toBeDefined();
         expect(savedIJR.name).toBe('my_first_jwt');
@@ -30,7 +30,7 @@ describe('issued-jwt-registry unit tests', () => {
             organization: 'orbis_operations',
         };
 
-        const savedChangedIJR = await env.ISSUED_JWT_WORKER.update('orbis_operations', changedIJR);
+        const savedChangedIJR = await env.ISSUED_JWT_REGISTRY.update('orbis_operations', changedIJR);
 
         expect(savedChangedIJR.id).toBeDefined();
         expect(savedChangedIJR.name).toBe('my_first_jwt');
@@ -47,8 +47,8 @@ describe('issued-jwt-registry unit tests', () => {
             expiry: new Date(Date.now() + 1000 * 60 * 60 * 92), //days away
             organization: 'orbis_operations',
         };
-        const madeIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', anotherIJR);
-        const retrievedIJR: IssuedJWTRegistry | undefined = await env.ISSUED_JWT_WORKER.get(
+        const madeIJR = await env.ISSUED_JWT_REGISTRY.create('orbis_operations', anotherIJR);
+        const retrievedIJR: IssuedJWTRegistry | undefined = await env.ISSUED_JWT_REGISTRY.get(
             'orbis_operations',
             madeIJR.id
         );
@@ -60,7 +60,7 @@ describe('issued-jwt-registry unit tests', () => {
             throw new Error('Could not retrieve the issued JWT registry entry');
         }
 
-        const deletedIJR = await env.ISSUED_JWT_WORKER.delete('orbis_operations', retrievedIJR.id);
+        const deletedIJR = await env.ISSUED_JWT_REGISTRY.delete('orbis_operations', retrievedIJR.id);
         expect(deletedIJR).toBe(true);
     });
 
@@ -83,13 +83,13 @@ describe('issued-jwt-registry unit tests', () => {
             organization: 'orbis_operations',
         };
 
-        await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR1);
-        await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR2);
-        await env.ISSUED_JWT_WORKER.create('coverent', newIJR2);
-        const org1BasedIJRs = await env.ISSUED_JWT_WORKER.list('orbis_operations');
+        await env.ISSUED_JWT_REGISTRY.create('orbis_operations', newIJR1);
+        await env.ISSUED_JWT_REGISTRY.create('orbis_operations', newIJR2);
+        await env.ISSUED_JWT_REGISTRY.create('coverent', newIJR2);
+        const org1BasedIJRs = await env.ISSUED_JWT_REGISTRY.list('orbis_operations');
 
-        const org2BasedIJRs = await env.ISSUED_JWT_WORKER.list('nc_state');
-        const org3BasedIJRs = await env.ISSUED_JWT_WORKER.list('coverent');
+        const org2BasedIJRs = await env.ISSUED_JWT_REGISTRY.list('nc_state');
+        const org3BasedIJRs = await env.ISSUED_JWT_REGISTRY.list('coverent');
         expect(org1BasedIJRs.length).toBe(2);
         expect(org2BasedIJRs.length).toBe(0);
         expect(org3BasedIJRs.length).toBe(1);
@@ -105,18 +105,18 @@ describe('issued-jwt-registry unit tests', () => {
             organization: 'orbis_operations',
         };
 
-        const madeIJR = await env.ISSUED_JWT_WORKER.create('orbis_operations', newIJR);
+        const madeIJR = await env.ISSUED_JWT_REGISTRY.create('orbis_operations', newIJR);
 
         // Verify it's in the list initially
-        const initialList = await env.ISSUED_JWT_WORKER.list('orbis_operations');
+        const initialList = await env.ISSUED_JWT_REGISTRY.list('orbis_operations');
         const initialCount = initialList.length;
 
         // Delete the item
-        const deletedIJR = await env.ISSUED_JWT_WORKER.delete('orbis_operations', madeIJR.id);
+        const deletedIJR = await env.ISSUED_JWT_REGISTRY.delete('orbis_operations', madeIJR.id);
         expect(deletedIJR).toBe(true);
 
         // Verify it's no longer in the list
-        const finalList = await env.ISSUED_JWT_WORKER.list('orbis_operations');
+        const finalList = await env.ISSUED_JWT_REGISTRY.list('orbis_operations');
         expect(finalList.length).toBe(initialCount - 1);
 
         // Verify the deleted item is not in the final list

--- a/apps/catalyst-ui-worker/wrangler.jsonc
+++ b/apps/catalyst-ui-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
             "service": "catalyst-ui-worker",
         },
         {
-            "binding": "ISSUED_JWT_WORKER",
+            "binding": "ISSUED_JWT_REGISTRY",
             "service": "issued-jwt-registry",
         },
         {
@@ -61,7 +61,7 @@
                     "service": "catalyst-ui-worker-preview",
                 },
                 {
-                    "binding": "ISSUED_JWT_WORKER",
+                    "binding": "ISSUED_JWT_REGISTRY",
                     "service": "issued-jwt-registry-preview",
                 },
                 {
@@ -103,7 +103,7 @@
                     "service": "catalyst-ui-worker-staging",
                 },
                 {
-                    "binding": "ISSUED_JWT_WORKER",
+                    "binding": "ISSUED_JWT_REGISTRY",
                     "service": "issued-jwt-registry-staging",
                 },
                 {
@@ -130,7 +130,7 @@
         //             "service": "catalyst-ui-worker-demo",
         //         },
 
-        //     { "binding": "ISSUED_JWT_WORKER", "service": "issued-jwt-registry-demo" },
+        //     { "binding": "ISSUED_JWT_REGISTRY", "service": "issued-jwt-registry-demo" },
         //     { "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API", "service": "data_channel_registrar-demo" },
         //     { "binding": "AUTHX_TOKEN_API", "service": "authx_token_api-demo" },
         //     { "binding": "AUTHX_AUTHZED_API", "service": "authx_authzed_api-demo" },
@@ -151,7 +151,7 @@
                     "service": "catalyst-ui-worker-uxr",
                 },
                 {
-                    "binding": "ISSUED_JWT_WORKER",
+                    "binding": "ISSUED_JWT_REGISTRY",
                     "service": "issued-jwt-registry-uxr",
                 },
                 {
@@ -193,7 +193,7 @@
                     "service": "catalyst-ui-worker-production",
                 },
                 {
-                    "binding": "ISSUED_JWT_WORKER",
+                    "binding": "ISSUED_JWT_REGISTRY",
                     "service": "issued-jwt-registry-production",
                 },
                 { "binding": "CATALYST_DATA_CHANNEL_REGISTRAR_API", "service": "data_channel_registrar-production" },

--- a/apps/catalyst_cli/tsconfig.tsbuildinfo
+++ b/apps/catalyst_cli/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/index.ts","./src/commands/data-channels/create.ts","./src/commands/data-channels/delete.ts","./src/commands/data-channels/index.ts","./src/commands/data-channels/list.ts","./src/commands/data-channels/read.ts","./src/commands/data-channels/update.ts","./src/utils/config.ts","./src/utils/graphql.ts","./src/utils/tables.ts"],"errors":true,"version":"5.8.3"}

--- a/apps/issued-jwt-registry/tests/env.d.ts
+++ b/apps/issued-jwt-registry/tests/env.d.ts
@@ -1,7 +1,7 @@
 declare module 'cloudflare:test' {
 	// Controls the type of `import("cloudflare:test").env
 	interface ProvidedEnv extends Env {
-		ISSUED_JWT_WORKER: Service<IssuedJWTRegistryWorker>;
+		ISSUED_JWT_REGISTRY: Service<IssuedJWTRegistryWorker>;
 		ISSUED_JWT_REGISTRY_DO: DurableObjectNamespace<I_JWT_Registry_DO>;
 	}
 

--- a/packages/schemas/src/core/env.ts
+++ b/packages/schemas/src/core/env.ts
@@ -25,7 +25,7 @@ export interface CloudflareEnv {
     AUTHX_AUTHZED_API: Service<unknown>;
     AUTHX_TOKEN_API: Service<unknown>;
     USER_CREDS_CACHE: Service<unknown>;
-    ISSUED_JWT_WORKER: Service<unknown>;
+    ISSUED_JWT_REGISTRY: Service<unknown>;
     CATALYST_DATA_CHANNEL_REGISTRAR_API: Service<unknown>;
     DATA_CHANNEL_CERTIFIER: Service<unknown>;
     ORGANIZATION_MATCHMAKING: Service<unknown>;
@@ -47,7 +47,7 @@ export type ServiceName =
     | 'AUTHX_AUTHZED_API'
     | 'AUTHX_TOKEN_API'
     | 'USER_CREDS_CACHE'
-    | 'ISSUED_JWT_WORKER'
+    | 'ISSUED_JWT_REGISTRY'
     | 'CATALYST_DATA_CHANNEL_REGISTRAR_API'
     | 'DATA_CHANNEL_CERTIFIER'
     | 'ORGANIZATION_MATCHMAKING';

--- a/packages/schemas/src/core/services.ts
+++ b/packages/schemas/src/core/services.ts
@@ -59,10 +59,10 @@ export function getUserCache(env: CloudflareEnv): WorkerService {
 
 /**
  * Helper to get Issued JWT Registry service
- * Returns the ISSUED_JWT_WORKER service binding
+ * Returns the ISSUED_JWT_REGISTRY service binding
  */
 export function getJWTRegistry(env: CloudflareEnv): WorkerService {
-    return getService(env, 'ISSUED_JWT_WORKER');
+    return getService(env, 'ISSUED_JWT_REGISTRY');
 }
 
 /**


### PR DESCRIPTION
### TL;DR

Renamed `ISSUED_JWT_WORKER` to `ISSUED_JWT_REGISTRY` across the codebase for consistency.

### What changed?

- Updated service binding name from `ISSUED_JWT_WORKER` to `ISSUED_JWT_REGISTRY` in multiple applications:
  - catalyst-ui-worker
  - authx_token_api
  - packages/schemas
- Added missing service bindings for `ISSUED_JWT_REGISTRY` in authx_token_api wrangler.jsonc for all environments
- Updated references in type definitions, tests, and documentation
- Added *.tsbuildinfo to .gitignore and removed an existing tsbuildinfo file

### How to test?

1. Verify that all services start correctly with the updated binding names
2. Run tests for the affected applications to ensure they pass with the new binding names
3. Test JWT-related functionality in the UI to confirm the service connections work properly

### Why make this change?

This change standardizes the naming convention across the codebase, making it more consistent with other service names. The new name `ISSUED_JWT_REGISTRY` better reflects the actual purpose of the service and aligns with how it's referenced in other parts of the system.