### PR TITLE
refactor(organization-matchmaking): schema patterns and error handling

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/partners.ts
+++ b/apps/catalyst-ui-worker/app/actions/partners.ts
@@ -1,43 +1,45 @@
 'use server';
 import { OrgInvite } from '@catalyst/schema_zod';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
-import { CloudflareEnv, getMatchmaking } from '@catalyst/schemas';
+import { CloudflareEnv, getMatchmaking, OrgInviteSchema } from '@catalyst/schemas';
 
 function getEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
 }
 
-export async function listInvites(token: string) {
+export async function listInvites(token: string): Promise<OrgInvite[]> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     const result = await matcher.listInvites({ cfToken: token });
     if (!result.success) {
         throw new Error(result.error);
     }
-    return result.invite as OrgInvite[];
+    // Runtime validation to ensure we got an array
+    return OrgInviteSchema.array().parse(result.data);
 }
 
-export async function sendInvite(receivingOrg: string, token: string, message: string) {
+export async function sendInvite(receivingOrg: string, token: string, message: string): Promise<OrgInvite> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     const result = await matcher.sendInvite(receivingOrg, { cfToken: token }, message);
     if (!result.success) {
         throw new Error('Sending Invite Failed');
     }
-    return result.invite as OrgInvite;
+    // Runtime validation to ensure we got a single invite
+    return OrgInviteSchema.parse(result.data);
 }
 
-export async function readInvite(inviteId: string, token: string) {
+export async function readInvite(inviteId: string, token: string): Promise<OrgInvite> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     const result = await matcher.readInvite(inviteId, { cfToken: token });
     if (!result.success) {
         throw new Error('Reading Invite Failed');
     }
-    return result.invite as OrgInvite;
+    return OrgInviteSchema.parse(result.data);
 }
 
-export async function declineInvite(inviteId: string, token: string) {
+export async function declineInvite(inviteId: string, token: string): Promise<OrgInvite> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     console.log({ inviteId, token });
@@ -45,10 +47,10 @@ export async function declineInvite(inviteId: string, token: string) {
     if (!result.success) {
         throw new Error('Declining Invite Failed');
     }
-    return result.invite as OrgInvite;
+    return OrgInviteSchema.parse(result.data);
 }
 
-export async function acceptInvite(inviteId: string, token: string) {
+export async function acceptInvite(inviteId: string, token: string): Promise<OrgInvite> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     const result = await matcher.acceptInvite(inviteId, { cfToken: token });
@@ -56,15 +58,15 @@ export async function acceptInvite(inviteId: string, token: string) {
     if (!result.success) {
         throw new Error('Accepting Invite Failed');
     }
-    return result.invite as OrgInvite;
+    return OrgInviteSchema.parse(result.data);
 }
 
-export async function togglePartnership(orgId: string, token: string) {
+export async function togglePartnership(orgId: string, token: string): Promise<OrgInvite> {
     const env = getEnv();
     const matcher = getMatchmaking(env);
     const result = await matcher.togglePartnership(orgId, { cfToken: token });
     if (!result.success) {
         throw new Error('Toggling Partnership Failed');
     }
-    return result.invite as OrgInvite;
+    return OrgInviteSchema.parse(result.data);
 }

--- a/apps/catalyst-ui-worker/tests/matchmaking.spec.ts
+++ b/apps/catalyst-ui-worker/tests/matchmaking.spec.ts
@@ -10,7 +10,7 @@ describe('organization matchmaking', () => {
             const invite = await stub.send('org1', 'org2');
             expect(invite.success).toBeTruthy();
             if (invite.success) {
-                const sendInviteParse = OrgInvite.safeParse(invite.invite);
+                const sendInviteParse = OrgInvite.safeParse(invite.data);
                 expect(sendInviteParse.success).toBeTruthy();
                 if (sendInviteParse.success) {
                     expect(sendInviteParse.data.sender).toBe('org1');
@@ -26,7 +26,7 @@ describe('organization matchmaking', () => {
             const org1ListResp = await stub.list('org1');
             expect(org1ListResp.success).toBeTruthy();
             if (org1ListResp.success) {
-                const org1ListParse = OrgInvite.array().safeParse(org1ListResp.invite);
+                const org1ListParse = OrgInvite.array().safeParse(org1ListResp.data);
                 expect(org1ListParse.success).toBeTruthy();
                 if (org1ListParse.success) {
                     const org1List = org1ListParse.data;
@@ -41,7 +41,7 @@ describe('organization matchmaking', () => {
             if (!inviteResp.success) {
                 throw new Error('this should have been a success');
             }
-            const invite = OrgInvite.parse(inviteResp.invite);
+            const invite = OrgInvite.parse(inviteResp.data);
             // org1 try to accept invite
             const failedResp = await stub.respond('org1', invite.id, OrgInviteStatus.enum.accepted);
             expect(failedResp.success).toBeFalsy();
@@ -50,7 +50,7 @@ describe('organization matchmaking', () => {
             if (!acceptedResp.success) {
                 throw new Error('this should be true');
             }
-            const acceptedInvite = OrgInvite.parse(acceptedResp.invite);
+            const acceptedInvite = OrgInvite.parse(acceptedResp.data);
             expect(acceptedInvite.status).toBe(OrgInviteStatus.enum.accepted);
 
             const listAcceptedResp = await stub.list('org1');
@@ -58,7 +58,7 @@ describe('organization matchmaking', () => {
                 throw new Error('this should be true');
             }
 
-            const listInvites = OrgInvite.array().parse(listAcceptedResp.invite);
+            const listInvites = OrgInvite.array().parse(listAcceptedResp.data);
             expect(listInvites).toHaveLength(1);
             expect(listInvites[0].status).toBe(OrgInviteStatus.enum.accepted);
         });
@@ -69,7 +69,7 @@ describe('organization matchmaking', () => {
             if (!inviteResp.success) {
                 throw new Error('this should be success');
             }
-            const invite = OrgInvite.parse(inviteResp.invite);
+            const invite = OrgInvite.parse(inviteResp.data);
             const org1DeclineResp = await stub.respond('org1', invite.id, OrgInviteStatus.enum.declined);
             expect(org1DeclineResp.success).toBeTruthy();
 
@@ -79,8 +79,8 @@ describe('organization matchmaking', () => {
                 throw new Error('these should be true');
             }
 
-            expect(OrgInvite.array().parse(org1ListResp.invite)).toHaveLength(0);
-            expect(OrgInvite.array().parse(org2ListResp.invite)).toHaveLength(0);
+            expect(OrgInvite.array().parse(org1ListResp.data)).toHaveLength(0);
+            expect(OrgInvite.array().parse(org2ListResp.data)).toHaveLength(0);
         });
         it('decline an invitation - org 2', async () => {
             const id = env.ORG_MATCHMAKING.idFromName('basic-decline-1');
@@ -89,7 +89,7 @@ describe('organization matchmaking', () => {
             if (!inviteResp.success) {
                 throw new Error('this should be success');
             }
-            const invite = OrgInvite.parse(inviteResp.invite);
+            const invite = OrgInvite.parse(inviteResp.data);
             const org2DeclineResp = await stub.respond('org2', invite.id, OrgInviteStatus.enum.declined);
             expect(org2DeclineResp.success).toBeTruthy();
 
@@ -99,8 +99,8 @@ describe('organization matchmaking', () => {
                 throw new Error('these should be true');
             }
 
-            expect(OrgInvite.array().parse(org1ListResp.invite)).toHaveLength(0);
-            expect(OrgInvite.array().parse(org2ListResp.invite)).toHaveLength(0);
+            expect(OrgInvite.array().parse(org1ListResp.data)).toHaveLength(0);
+            expect(OrgInvite.array().parse(org2ListResp.data)).toHaveLength(0);
         });
     });
 });

--- a/apps/organization_matchmaking/package.json
+++ b/apps/organization_matchmaking/package.json
@@ -15,7 +15,8 @@
 		"cf-typegen": "wrangler types"
 	},
 	"dependencies": {
-		"@catalyst/schema_zod": "workspace:*"
+		"@catalyst/schema_zod": "workspace:*",
+		"@catalyst/schemas": "workspace:*"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.23",

--- a/apps/organization_matchmaking/test/index.spec.ts
+++ b/apps/organization_matchmaking/test/index.spec.ts
@@ -1,8 +1,8 @@
 // test/index.spec.ts
 import { env, runInDurableObject, SELF } from 'cloudflare:test';
-import { assert, describe, expect, it, beforeEach } from 'vitest';
-import { OrgInvite, OrgInviteResponse, OrgInviteStatus } from '../../../packages/schema_zod';
-import { User } from '../../../packages/schema_zod';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { OrgInvite, OrgInviteStatusSchema } from '@catalyst/schemas';
+import { User } from '@catalyst/schema_zod';
 
 const SENDER_ORGANIZATION = 'default';
 
@@ -42,16 +42,6 @@ function generateInvites(maxCount?: number) {
 	return invites;
 }
 
-// Add type guard for successful response
-function isSuccessfulResponse(response: OrgInviteResponse): response is { success: true; invite: OrgInvite | OrgInvite[] } {
-	return response.success === true;
-}
-
-// Add type guard for array of invites
-function isInviteArray(invite: OrgInvite | OrgInvite[]): invite is OrgInvite[] {
-	return Array.isArray(invite);
-}
-
 // Standardize mock user creation
 const createMockUser = (orgId: string) =>
 	({
@@ -67,44 +57,33 @@ describe('organization matchmaking worker', () => {
 		expect(worker).toBeDefined();
 	});
 
-	// send invite
+	// send invite (DO method returns entity directly)
 	it('should be able to send an invite', async () => {
 		const id = await env.ORG_MATCHMAKING.idFromName('default');
 		const stub = await env.ORG_MATCHMAKING.get(id);
 
 		const inviteToSend = generateInvites(1)[0];
-		const response: OrgInviteResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		const invite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
 
-		const parsedResult = OrgInviteResponse.safeParse(response);
-		expect(parsedResult.success).toBe(true);
-
-		expect(response.success).toBe(true);
-		if (isSuccessfulResponse(response)) {
-			const inviteResponse = isInviteArray(response.invite) ? response.invite[0] : response.invite;
-			expect(inviteResponse).toBeDefined();
-		}
+		expect(invite).toBeDefined();
+		expect(invite.sender).toBe(inviteToSend.sender);
+		expect(invite.receiver).toBe(inviteToSend.receiver);
+		expect(invite.message).toBe(inviteToSend.message);
+		expect(invite.status).toBe('pending');
 	});
 
-	// test list invites
+	// test list invites (DO method returns array directly)
 	it('should be able to list invites', async () => {
 		const id = env.ORG_MATCHMAKING.idFromName('default');
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		const invite = generateInvites(1)[0];
 
-		const response: OrgInviteResponse = await stub.list(invite.sender);
+		const invites: OrgInvite[] = await stub.list(invite.sender);
 
-		// check if the response is a valid OrgInviteResponse
-		const parsedResult = OrgInviteResponse.safeParse(response);
-		expect(parsedResult.success).toBe(true);
-
-		// check if the response is a valid OrgInviteResponse
-		expect(response.success).toBe(true);
-
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		expect(response.invite).toBeInstanceOf(Array);
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		expect(response.invite.length).toBe(1);
+		// check if the response is an array
+		expect(invites).toBeInstanceOf(Array);
+		expect(invites.length).toBe(1);
 	});
 
 	// create more invites
@@ -113,42 +92,25 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (instance, state) => {
+		await runInDurableObject(stub, async (_instance: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		const invites = generateInvites();
 
 		for (const invite of invites) {
-			const response: OrgInviteResponse = await stub.send(invite.sender, invite.receiver, invite.message);
-			expect(response.success).toBe(true); // check if the invite was sent successfully
+			const createdInvite: OrgInvite = await stub.send(invite.sender, invite.receiver, invite.message);
+			expect(createdInvite).toBeDefined(); // check if the invite was sent successfully
 		}
 
-		const response: OrgInviteResponse = await stub.list('default');
-		expect(response.success).toBe(true);
-
-		// @ts-expect-error: ts complains about the type of the invite because no check before
+		const senderInvites: OrgInvite[] = await stub.list('default');
 		// SENDER ORGANIZATION should have the same number of invites as the number of invites sent
-		expect(response.invite.length).toBe(invites.length);
+		expect(senderInvites.length).toBe(invites.length);
 
 		// check if all the invites exists in the mailbox of the receiver
-		if (!response.success) {
-			assert(false);
-		}
-
-		const mailboxInvites = response.invite as OrgInvite[];
-		if (!Array.isArray(mailboxInvites)) {
-			throw new Error('Expected response.invite to be an array');
-		}
-
-		for (const invite of mailboxInvites) {
-			const receiverMailbox = await stub.list(invite.receiver);
-			expect(receiverMailbox.success).toBe(true);
-			if (!receiverMailbox.success) {
-				throw new Error('Failed to list receiver mailbox');
-			}
-			const receiverInvites = receiverMailbox.invite as OrgInvite[];
-			expect(receiverInvites.length).toBe(1);
+		for (const invite of senderInvites) {
+			const receiverMailbox: OrgInvite[] = await stub.list(invite.receiver);
+			expect(receiverMailbox.length).toBe(1);
 		}
 	});
 
@@ -157,29 +119,11 @@ describe('organization matchmaking worker', () => {
 		const id = env.ORG_MATCHMAKING.idFromName('default');
 		const stub = env.ORG_MATCHMAKING.get(id);
 
-		const response = await stub.list('default');
-		const parsedResponse = OrgInviteResponse.parse(response);
-		expect(parsedResponse.success).toBe(true);
-		if (!parsedResponse.success) {
-			throw new Error('Failed to list invites');
-		}
-
-		// At this point TypeScript knows parsedResponse.success is true
-		const listInvites = Array.isArray(parsedResponse.invite) ? parsedResponse.invite : [parsedResponse.invite];
-		if (!Array.isArray(listInvites)) {
-			throw new Error('Expected response.invite to be an array');
-		}
+		const listInvites: OrgInvite[] = await stub.list('default');
+		expect(listInvites.length).toBeGreaterThan(0);
 
 		for (const invite of listInvites) {
-			const readResponse = await stub.read('default', invite.id);
-			const parsedReadResponse = OrgInviteResponse.parse(readResponse);
-			expect(parsedReadResponse.success).toBe(true);
-			if (!parsedReadResponse.success) {
-				throw new Error('Failed to read invite');
-			}
-
-			// At this point TypeScript knows parsedReadResponse.success is true
-			const readInvite = Array.isArray(parsedReadResponse.invite) ? parsedReadResponse.invite[0] : parsedReadResponse.invite;
+			const readInvite: OrgInvite = await stub.read('default', invite.id);
 			expect(readInvite.id).toStrictEqual(invite.id);
 		}
 	});
@@ -189,21 +133,17 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (instance, state) => {
+		await runInDurableObject(stub, async (_instance: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		const inviteToSend = generateInvites(1)[0];
 
-		const inviteSentResponse: OrgInviteResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentResponse.success).toBe(true);
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const inviteResponse = inviteSentResponse.invite;
-		expect(inviteResponse).toBeDefined();
-
-		const response: OrgInviteResponse = await stub.respond(inviteToSend.receiver, inviteResponse.id, OrgInviteStatus.enum.accepted);
-		expect(response.success).toBe(true);
+		const acceptedInvite: OrgInvite = await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+		expect(acceptedInvite.status).toBe('accepted');
 	});
 
 	it('organization should be able to respond DECLINE to an invite', async () => {
@@ -211,33 +151,25 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		const inviteToSend = generateInvites(1)[0];
 
-		const inviteSentRespone: OrgInviteResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentRespone.success).toBe(true);
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const inviteResponse = inviteSentRespone.invite;
-		expect(inviteResponse).toBeDefined();
+		const declinedInvite: OrgInvite = await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.declined);
+		expect(declinedInvite.status).toBe('declined');
 
-		const response: OrgInviteResponse = await stub.respond(inviteToSend.receiver, inviteResponse.id, OrgInviteStatus.enum.declined);
-		expect(response.success).toBe(true);
+		// check if the invite is still in the sender's mailbox (should be removed)
+		const senderMailbox: OrgInvite[] = await stub.list(inviteToSend.sender);
+		expect(senderMailbox.length).toStrictEqual(0);
 
-		// check if the invite is still in the sender's mailbox
-		const senderMailbox: OrgInviteResponse = await stub.list(inviteToSend.sender);
-		expect(senderMailbox.success).toBe(true);
-		// @ts-expect-error: TypeScript doesn't know success is true here
-		expect(senderMailbox.invite.length).toStrictEqual(0);
-
-		// check if the invite is still in receiver's mailbox
-		const receiverMailbox: OrgInviteResponse = await stub.list(inviteToSend.receiver);
-		expect(receiverMailbox.success).toBe(true);
-		// @ts-expect-error: TypeScript doesn't know success is true here
-		expect(receiverMailbox.invite.length).toStrictEqual(0);
+		// check if the invite is still in receiver's mailbox (should be removed)
+		const receiverMailbox: OrgInvite[] = await stub.list(inviteToSend.receiver);
+		expect(receiverMailbox.length).toStrictEqual(0);
 	});
 
 	it('organization cannot respond to ACCEPT/DECLINE to their own invite', async () => {
@@ -246,20 +178,23 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		const inviteToSend = generateInvites(1)[0];
 
-		const inviteSentRespone: OrgInviteResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const invite: OrgInvite = inviteSentRespone.invite;
-		expect(invite).toBeDefined();
-
-		const response: OrgInviteResponse = await stub.respond('default', invite.id, OrgInviteStatus.enum.accepted);
-		expect(response.success, 'Organization should not be able to respond to an invite it made; default').toBe(false);
+		// Try to accept as sender - should throw
+		try {
+			await stub.respond('default', createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+			expect.fail('Should have thrown error when sender tries to accept their own invite');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('cannot accept their own invite');
+		}
 	});
 
 	// be able to toggle an invite
@@ -268,31 +203,21 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		const inviteToSend = generateInvites(1)[0];
 
-		const inviteSentRespone: OrgInviteResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentRespone.success).toBe(true);
-
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const createdInvite = inviteSentRespone.invite as OrgInvite;
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
 		// get the invite from the sender's mailbox
 		// validate that status is pending
-		const readResponse: OrgInviteResponse = await stub.read(inviteToSend.sender, createdInvite.id);
-		expect(readResponse.success).toBe(true);
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		expect(readResponse.invite.status).toBe(OrgInviteStatus.enum.pending);
+		const readInvite: OrgInvite = await stub.read(inviteToSend.sender, createdInvite.id);
+		expect(readInvite.status).toBe(OrgInviteStatusSchema.enum.pending);
 
-		const toggledInviteResponse: OrgInviteResponse = await stub.togglePartnership('default', createdInvite.id);
-
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const toggledInvite = toggledInviteResponse.invite as OrgInvite;
-		// @ts-expect-error: ts complains about the type of the invite because no check before
-		const readInvite = readResponse.invite as OrgInvite;
+		const toggledInvite: OrgInvite = await stub.togglePartnership('default', createdInvite.id);
 
 		// validate that the invite is toggled
 		expect(toggledInvite.isActive).toBe(!readInvite.isActive);
@@ -303,18 +228,17 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
-		// Try to read a non-existent invite
-		const response = await stub.read('default', 'non-existent-invite-id');
-		const parsedResponse = OrgInviteResponse.parse(response);
-
-		// Verify the response
-		expect(parsedResponse.success).toBe(false);
-		if (!parsedResponse.success) {
-			expect(parsedResponse.error).toBe('catalyst cannot find the invite');
+		// Try to read a non-existent invite - DO method should throw
+		try {
+			await stub.read('default', 'non-existent-invite-id');
+			expect.fail('Should have thrown InviteNotFoundError');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('not found');
 		}
 	});
 
@@ -323,18 +247,17 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
-		// Try to toggle a non-existent invite
-		const response = await stub.togglePartnership('default', 'non-existent-invite-id');
-		const parsedResponse = OrgInviteResponse.parse(response);
-
-		// Verify the response
-		expect(parsedResponse.success).toBe(false);
-		if (!parsedResponse.success) {
-			expect(parsedResponse.error).toBe('catalyst cannot find the invite');
+		// Try to toggle a non-existent invite - DO method should throw
+		try {
+			await stub.togglePartnership('default', 'non-existent-invite-id');
+			expect.fail('Should have thrown InviteNotFoundError');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('not found');
 		}
 	});
 
@@ -343,29 +266,22 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		// Create an invite
 		const inviteToSend = generateInvites(1)[0];
-		const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentResponse.success).toBe(true);
-		if (!inviteSentResponse.success) {
-			throw new Error('Failed to send invite');
-		}
-
-		// Get the invite ID
-		const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
 		// Try to change status back to pending (which should fail)
-		const response = await stub.respond(inviteToSend.receiver, invite.id, OrgInviteStatus.enum.pending);
-		const parsedResponse = OrgInviteResponse.parse(response);
-
-		// Verify the response
-		expect(parsedResponse.success).toBe(false);
-		if (!parsedResponse.success) {
-			expect(parsedResponse.error).toBe('cannot change back to pending');
+		try {
+			await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.pending);
+			expect.fail('Should have thrown error when trying to change back to pending');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('Cannot change back to pending');
 		}
 	});
 
@@ -374,7 +290,7 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
@@ -386,55 +302,23 @@ describe('organization matchmaking worker', () => {
 
 		const sentInvites: OrgInvite[] = [];
 		for (const invite of invites) {
-			const response = await stub.send(invite.sender, invite.receiver, invite.message);
-			expect(response.success).toBe(true);
-			if (!response.success) {
-				throw new Error('Failed to send invite');
-			}
-			const sentInvite = Array.isArray(response.invite) ? response.invite[0] : response.invite;
-			sentInvites.push(sentInvite);
+			const createdInvite: OrgInvite = await stub.send(invite.sender, invite.receiver, invite.message);
+			sentInvites.push(createdInvite);
 		}
 
 		// Get the invite from both mailboxes before toggle
-		const senderReadResponse = await stub.read(invites[1].sender, sentInvites[1].id);
-		const receiverReadResponse = await stub.read(invites[1].receiver, sentInvites[1].id);
-		expect(senderReadResponse.success).toBe(true);
-		expect(receiverReadResponse.success).toBe(true);
-		if (!senderReadResponse.success || !receiverReadResponse.success) {
-			throw new Error('Failed to read invite');
-		}
-		const senderReadInvite = Array.isArray(senderReadResponse.invite) ? senderReadResponse.invite[0] : senderReadResponse.invite;
-		const receiverReadInvite = Array.isArray(receiverReadResponse.invite) ? receiverReadResponse.invite[0] : receiverReadResponse.invite;
+		const senderReadInvite: OrgInvite = await stub.read(invites[1].sender, sentInvites[1].id);
+		const receiverReadInvite: OrgInvite = await stub.read(invites[1].receiver, sentInvites[1].id);
 		expect(senderReadInvite.isActive).toBe(true);
 		expect(receiverReadInvite.isActive).toBe(true);
 
 		// Toggle the invite
-		const toggledInviteResponse = await stub.togglePartnership(invites[1].sender, sentInvites[1].id);
-		expect(toggledInviteResponse.success).toBe(true);
-		if (!toggledInviteResponse.success) {
-			throw new Error('Failed to toggle invite');
-		}
-
-		const toggledInvite = Array.isArray(toggledInviteResponse.invite) ? toggledInviteResponse.invite[0] : toggledInviteResponse.invite;
+		const toggledInvite: OrgInvite = await stub.togglePartnership(invites[1].sender, sentInvites[1].id);
 		expect(toggledInvite.isActive).toBe(false);
 
 		// Verify the toggle in both mailboxes
-		const receiverListResponse = await stub.list(invites[1].receiver);
-		const senderListResponse = await stub.list(invites[1].sender);
-
-		const parsedReceiverResponse = OrgInviteResponse.parse(receiverListResponse);
-		const parsedSenderResponse = OrgInviteResponse.parse(senderListResponse);
-
-		expect(parsedReceiverResponse.success).toBe(true);
-		expect(parsedSenderResponse.success).toBe(true);
-		if (!parsedReceiverResponse.success || !parsedSenderResponse.success) {
-			throw new Error('Failed to list invites');
-		}
-
-		const receiverMailboxInvites = Array.isArray(parsedReceiverResponse.invite)
-			? parsedReceiverResponse.invite
-			: [parsedReceiverResponse.invite];
-		const senderMailboxInvites = Array.isArray(parsedSenderResponse.invite) ? parsedSenderResponse.invite : [parsedSenderResponse.invite];
+		const receiverMailboxInvites: OrgInvite[] = await stub.list(invites[1].receiver);
+		const senderMailboxInvites: OrgInvite[] = await stub.list(invites[1].sender);
 
 		expect(receiverMailboxInvites.length).toBe(3);
 		expect(senderMailboxInvites.length).toBe(3);
@@ -462,17 +346,17 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
-		// Try to respond to a non-existent invite
-		const response = await stub.respond('default', 'non-existent-id', OrgInviteStatus.enum.accepted);
-
-		// Verify the response
-		expect(response.success).toBe(false);
-		if (!response.success) {
-			expect(response.error).toBe('catalyst cannot find the invite');
+		// Try to respond to a non-existent invite - DO method should throw
+		try {
+			await stub.respond('default', 'non-existent-id', OrgInviteStatusSchema.enum.accepted);
+			expect.fail('Should have thrown InviteNotFoundError');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('not found');
 		}
 	});
 
@@ -481,28 +365,22 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		// Create an invite
 		const inviteToSend = generateInvites(1)[0];
-		const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentResponse.success).toBe(true);
-		if (!inviteSentResponse.success) {
-			throw new Error('Failed to send invite');
-		}
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
-		// Get the invite ID
-		const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
-
-		// Try to accept the invite as the sender
-		const response = await stub.respond(inviteToSend.sender, invite.id, OrgInviteStatus.enum.accepted);
-
-		// Verify the response
-		expect(response.success).toBe(false);
-		if (!response.success) {
-			expect(response.error).toBe('sender cannot accept their own invite');
+		// Try to accept the invite as the sender - DO method should throw
+		try {
+			await stub.respond(inviteToSend.sender, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+			expect.fail('Should have thrown error when sender tries to accept their own invite');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('cannot accept their own invite');
 		}
 	});
 
@@ -511,37 +389,31 @@ describe('organization matchmaking worker', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// clear the storage if any invites are present
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 
 		// Create an invite
 		const inviteToSend = generateInvites(1)[0];
-		const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-		expect(inviteSentResponse.success).toBe(true);
-		if (!inviteSentResponse.success) {
-			throw new Error('Failed to send invite');
-		}
-
-		// Get the invite ID
-		const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+		const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+		expect(createdInvite).toBeDefined();
 
 		// Manually delete the invite from the sender's mailbox to simulate inconsistency
-		await runInDurableObject(stub, async (_, state) => {
-			const senderMailbox = (await state.storage.get<OrgInvite[]>(inviteToSend.sender)) ?? [];
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			const senderMailbox = ((await state.storage.get(inviteToSend.sender)) as OrgInvite[]) ?? [];
 			await state.storage.put(
 				inviteToSend.sender,
-				senderMailbox.filter((i) => i.id !== invite.id),
+				senderMailbox.filter((i: OrgInvite) => i.id !== createdInvite.id),
 			);
 		});
 
-		// Try to respond to the invite as the receiver
-		const response = await stub.respond(inviteToSend.receiver, invite.id, OrgInviteStatus.enum.accepted);
-
-		// Verify the response
-		expect(response.success).toBe(false);
-		if (!response.success) {
-			expect(response.error).toBe('catalyst cannot find the other invite');
+		// Try to respond to the invite as the receiver - DO method should throw
+		try {
+			await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+			expect.fail('Should have thrown InviteNotFoundError');
+		} catch (error) {
+			expect(error).toBeDefined();
+			expect((error as Error).message).toContain('not found');
 		}
 	});
 
@@ -552,14 +424,8 @@ describe('organization matchmaking worker', () => {
 
 			// Create an invite first
 			const inviteToSend = generateInvites(1)[0];
-			const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-			expect(inviteSentResponse.success).toBe(true);
-			if (!inviteSentResponse.success) {
-				throw new Error('Failed to send invite');
-			}
-
-			// Get the invite ID
-			const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+			const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+			expect(createdInvite).toBeDefined();
 
 			const mockUser: User = {
 				userId: 'test-user',
@@ -567,20 +433,21 @@ describe('organization matchmaking worker', () => {
 			} as User;
 
 			// Mock the USERCACHE binding used inside the worker
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
 			// Read the invite using the worker
 			const worker = SELF;
-			const response = await worker.readInvite(invite.id, { cfToken: 'valid-token' });
+			const response = await worker.readInvite(createdInvite.id, { cfToken: 'valid-token' });
 
 			expect(response.success).toBe(true);
 			if (!response.success) {
 				throw new Error('Failed to read invite');
 			}
-			// @ts-expect-error: TypeScript doesn't know invite is a single object here
-			expect(response.invite.id).toBe(invite.id);
+			expect(response.data).toBeDefined();
+			// data should be a single OrgInvite, not an array
+			const invite = response.data as OrgInvite;
+			expect(invite.id).toBe(createdInvite.id);
 		});
 
 		it('should return error when token is missing', async () => {
@@ -589,7 +456,7 @@ describe('organization matchmaking worker', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a verifiable credential');
+				expect(response.error).toBe('No verifiable credential found');
 			}
 		});
 
@@ -602,7 +469,7 @@ describe('organization matchmaking worker', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a valid user');
+				expect(response.error).toBe('Invalid or non-existent user');
 			}
 		});
 
@@ -612,30 +479,23 @@ describe('organization matchmaking worker', () => {
 
 			// Create an invite first
 			const inviteToSend = generateInvites(1)[0];
-			const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-			expect(inviteSentResponse.success).toBe(true);
-			if (!inviteSentResponse.success) {
-				throw new Error('Failed to send invite');
-			}
-
-			// Get the invite ID
-			const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+			const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+			expect(createdInvite).toBeDefined();
 
 			// Mock the USERCACHE binding with a user
 			const mockUser = {
 				userId: 'test-user',
 				orgId: inviteToSend.sender,
 			} as User;
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => false;
 
 			const worker = SELF;
-			const response = await worker.readInvite(invite.id, { cfToken: 'valid-token' });
+			const response = await worker.readInvite(createdInvite.id, { cfToken: 'valid-token' });
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst rejects users ability to add an org partner');
+				expect(response.error).toBe('Permission denied: update org partners');
 			}
 		});
 	});
@@ -646,7 +506,7 @@ describe('organization matchmaking worker', () => {
 			const stub = env.ORG_MATCHMAKING.get(id);
 
 			// Clear storage before each test
-			await runInDurableObject(stub, async (_, state) => {
+			await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 				await state.storage.deleteAll();
 			});
 		});
@@ -657,13 +517,8 @@ describe('organization matchmaking worker', () => {
 
 			// Create an invite
 			const inviteToSend = generateInvites(1)[0];
-			const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-			expect(inviteSentResponse.success).toBe(true);
-			if (!inviteSentResponse.success) {
-				throw new Error('Failed to send invite');
-			}
-
-			const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+			const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+			expect(createdInvite).toBeDefined();
 
 			// Mock the USERCACHE binding with a user
 			const mockUser = {
@@ -673,20 +528,19 @@ describe('organization matchmaking worker', () => {
 
 			await env.AUTHZED.addUserToOrg(inviteToSend.sender, mockUser.userId);
 
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
 			// Toggle the invite using the worker
 			const worker = SELF;
-			const response = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			const response = await worker.togglePartnership(createdInvite.id, { cfToken: 'valid-token' });
 			expect(response.success).toBe(true);
 			if (!response.success) {
 				throw new Error('Failed to toggle invite');
 			}
 
 			// Verify the toggle
-			const toggledInvite = Array.isArray(response.invite) ? response.invite[0] : response.invite;
+			const toggledInvite = response.data as OrgInvite;
 			expect(toggledInvite.isActive).toBe(false);
 		});
 
@@ -696,7 +550,7 @@ describe('organization matchmaking worker', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a verifiable credential');
+				expect(response.error).toBe('No verifiable credential found');
 			}
 		});
 
@@ -709,7 +563,7 @@ describe('organization matchmaking worker', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a valid user');
+				expect(response.error).toBe('Invalid or non-existent user');
 			}
 		});
 
@@ -719,29 +573,23 @@ describe('organization matchmaking worker', () => {
 
 			// Create an invite
 			const inviteToSend = generateInvites(1)[0];
-			const inviteSentResponse = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
-			expect(inviteSentResponse.success).toBe(true);
-			if (!inviteSentResponse.success) {
-				throw new Error('Failed to send invite');
-			}
-
-			const invite = Array.isArray(inviteSentResponse.invite) ? inviteSentResponse.invite[0] : inviteSentResponse.invite;
+			const createdInvite: OrgInvite = await stub.send(inviteToSend.sender, inviteToSend.receiver, inviteToSend.message);
+			expect(createdInvite).toBeDefined();
 
 			// Mock the USERCACHE binding with a user
 			const mockUser = {
 				userId: 'test-user',
 				orgId: inviteToSend.sender,
 			} as User;
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => false;
 
 			const worker = SELF;
-			const response = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			const response = await worker.togglePartnership(createdInvite.id, { cfToken: 'valid-token' });
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst rejects users ability to add an org partner');
+				expect(response.error).toBe('Permission denied: update org partners');
 			}
 		});
 
@@ -751,7 +599,6 @@ describe('organization matchmaking worker', () => {
 				userId: 'test-user',
 				orgId: SENDER_ORGANIZATION,
 			} as User;
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -760,7 +607,7 @@ describe('organization matchmaking worker', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst cannot find the invite');
+				expect(response.error).toContain('not found');
 			}
 		});
 	});
@@ -772,7 +619,7 @@ describe('Invite Management', () => {
 		const stub = env.ORG_MATCHMAKING.get(id);
 
 		// Clear storage before each test
-		await runInDurableObject(stub, async (_, state) => {
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
 	});
@@ -783,7 +630,6 @@ describe('Invite Management', () => {
 			const mockUser = createMockUser('default');
 
 			await env.AUTHZED.addUserToOrg(mockUser.orgId, mockUser.userId);
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -795,7 +641,7 @@ describe('Invite Management', () => {
 				throw new Error('Failed to send invite');
 			}
 
-			const invite = Array.isArray(response.invite) ? response.invite[0] : response.invite;
+			const invite = response.data as OrgInvite;
 			expect(invite.sender).toBe(inviteToSend.sender);
 			expect(invite.receiver).toBe(inviteToSend.receiver);
 			expect(invite.message).toBe(inviteToSend.message);
@@ -809,7 +655,7 @@ describe('Invite Management', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a verifiable credential');
+				expect(response.error).toBe('No verifiable credential found');
 			}
 		});
 
@@ -819,7 +665,6 @@ describe('Invite Management', () => {
 
 			// Add user to org first
 			await env.AUTHZED.addUserToOrg(mockUser.orgId, mockUser.userId);
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => false;
 
@@ -827,7 +672,7 @@ describe('Invite Management', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst rejects users abiltiy to add an org partner');
+				expect(response.error).toBe('Permission denied: send org invites');
 			}
 		});
 	});
@@ -841,7 +686,6 @@ describe('Invite Management', () => {
 			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
 			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
 
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => senderUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -853,9 +697,8 @@ describe('Invite Management', () => {
 				throw new Error('Failed to send invite');
 			}
 
-			const invite = Array.isArray(sendResponse.invite) ? sendResponse.invite[0] : sendResponse.invite;
+			const invite = sendResponse.data as OrgInvite;
 
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => receiverUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -866,7 +709,7 @@ describe('Invite Management', () => {
 				throw new Error('Failed to accept invite');
 			}
 
-			const acceptedInvite = Array.isArray(acceptResponse.invite) ? acceptResponse.invite[0] : acceptResponse.invite;
+			const acceptedInvite = acceptResponse.data as OrgInvite;
 			expect(acceptedInvite.status).toBe('accepted');
 		});
 
@@ -876,7 +719,6 @@ describe('Invite Management', () => {
 
 			// First send an invite
 			await env.AUTHZED.addUserToOrg(mockUser.orgId, mockUser.userId);
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -888,14 +730,14 @@ describe('Invite Management', () => {
 				throw new Error('Failed to send invite');
 			}
 
-			const invite = Array.isArray(sendResponse.invite) ? sendResponse.invite[0] : sendResponse.invite;
+			const invite = sendResponse.data as OrgInvite;
 
 			// Try to accept as sender
 			const acceptResponse = await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
 
 			expect(acceptResponse.success).toBe(false);
 			if (!acceptResponse.success) {
-				expect(acceptResponse.error).toBe('sender cannot accept their own invite');
+				expect(acceptResponse.error).toContain('cannot accept their own invite');
 			}
 		});
 	});
@@ -909,7 +751,6 @@ describe('Invite Management', () => {
 			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
 			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
 
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => senderUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -921,9 +762,8 @@ describe('Invite Management', () => {
 				throw new Error('Failed to send invite');
 			}
 
-			const invite = Array.isArray(sendResponse.invite) ? sendResponse.invite[0] : sendResponse.invite;
+			const invite = sendResponse.data as OrgInvite;
 
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => receiverUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -934,7 +774,7 @@ describe('Invite Management', () => {
 				throw new Error('Failed to decline invite');
 			}
 
-			const declinedInvite = Array.isArray(declineResponse.invite) ? declineResponse.invite[0] : declineResponse.invite;
+			const declinedInvite = declineResponse.data as OrgInvite;
 			expect(declinedInvite.status).toBe('declined');
 		});
 	});
@@ -945,7 +785,6 @@ describe('Invite Management', () => {
 			const mockUser = createMockUser('default');
 
 			await env.AUTHZED.addUserToOrg(mockUser.orgId, mockUser.userId);
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
 
@@ -963,7 +802,7 @@ describe('Invite Management', () => {
 				throw new Error('Failed to list invites');
 			}
 
-			const listedInvites = Array.isArray(listResponse.invite) ? listResponse.invite : [listResponse.invite];
+			const listedInvites = listResponse.data as OrgInvite[];
 			expect(listedInvites).toHaveLength(invites.length);
 
 			// Verify each invite
@@ -982,7 +821,7 @@ describe('Invite Management', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a verifiable credential');
+				expect(response.error).toBe('No verifiable credential found');
 			}
 		});
 
@@ -994,7 +833,7 @@ describe('Invite Management', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst did not find a valid user');
+				expect(response.error).toBe('Invalid or non-existent user');
 			}
 		});
 
@@ -1004,7 +843,6 @@ describe('Invite Management', () => {
 
 			// Add user to org first
 			await env.AUTHZED.addUserToOrg(mockUser.orgId, mockUser.userId);
-			// @ts-expect-error: Mock implementation doesn't match expected type
 			env.USERCACHE.getUser = async () => mockUser;
 			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => false;
 
@@ -1012,7 +850,7 @@ describe('Invite Management', () => {
 
 			expect(response.success).toBe(false);
 			if (!response.success) {
-				expect(response.error).toBe('catalyst rejects users abiltiy to add an org partner');
+				expect(response.error).toBe('Permission denied: list org invites');
 			}
 		});
 	});

--- a/packages/schemas/src/core/errors.ts
+++ b/packages/schemas/src/core/errors.ts
@@ -1,0 +1,131 @@
+/**
+ * Typed error classes for Catalyst applications
+ *
+ * These errors provide structured error information that can be easily
+ * serialized and transmitted across service boundaries.
+ */
+
+/**
+ * Base error class for all Catalyst errors
+ */
+export class CatalystError extends Error {
+    constructor(
+        public readonly code: string,
+        message: string,
+        public readonly details?: unknown
+    ) {
+        super(message);
+        this.name = 'CatalystError';
+
+        // Maintains proper stack trace for where our error was thrown (only available on V8)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+
+    /**
+     * Convert error to plain object for serialization
+     */
+    toJSON() {
+        return {
+            code: this.code,
+            message: this.message,
+            details: this.details,
+            name: this.name,
+        };
+    }
+}
+
+/**
+ * Error thrown when a requested resource is not found
+ */
+export class NotFoundError extends CatalystError {
+    constructor(resource: string, identifier?: string) {
+        const message = identifier ? `${resource} '${identifier}' not found` : `${resource} not found`;
+        super('NOT_FOUND', message, { resource, identifier });
+    }
+}
+
+/**
+ * Error thrown when an invite is not found
+ */
+export class InviteNotFoundError extends CatalystError {
+    constructor(inviteId?: string) {
+        const message = inviteId ? `Invite '${inviteId}' not found` : 'Invite not found';
+        super('INVITE_NOT_FOUND', message, { resource: 'Invite', identifier: inviteId });
+    }
+}
+
+/**
+ * Error thrown when authentication credentials are missing or invalid
+ */
+export class UnauthorizedError extends CatalystError {
+    constructor(message = 'No verifiable credential found') {
+        super('UNAUTHORIZED', message);
+    }
+}
+
+/**
+ * Error thrown when a user is invalid or not found
+ */
+export class InvalidUserError extends CatalystError {
+    constructor(message = 'Invalid or non-existent user') {
+        super('INVALID_USER', message);
+    }
+}
+
+/**
+ * Error thrown when a user lacks necessary permissions
+ */
+export class PermissionDeniedError extends CatalystError {
+    constructor(action?: string) {
+        const message = action ? `Permission denied: ${action}` : 'Permission denied';
+        super('PERMISSION_DENIED', message, { action });
+    }
+}
+
+/**
+ * Error thrown when an operation is invalid or not allowed
+ */
+export class InvalidOperationError extends CatalystError {
+    constructor(message: string, details?: unknown) {
+        super('INVALID_OPERATION', message, details);
+    }
+}
+
+/**
+ * Error thrown when input validation fails
+ */
+export class ValidationError extends CatalystError {
+    constructor(message: string, validationErrors?: unknown) {
+        super('VALIDATION_ERROR', message, validationErrors);
+    }
+}
+
+/**
+ * Error thrown when a resource already exists
+ */
+export class AlreadyExistsError extends CatalystError {
+    constructor(resource: string, identifier?: string) {
+        const message = identifier ? `${resource} '${identifier}' already exists` : `${resource} already exists`;
+        super('ALREADY_EXISTS', message, { resource, identifier });
+    }
+}
+
+/**
+ * Helper function to convert any error to CatalystError
+ */
+export function toCatalystError(error: unknown): CatalystError {
+    if (error instanceof CatalystError) {
+        return error;
+    }
+
+    if (error instanceof Error) {
+        return new CatalystError('INTERNAL_ERROR', error.message, {
+            originalError: error.name,
+            stack: error.stack,
+        });
+    }
+
+    return new CatalystError('UNKNOWN_ERROR', 'An unknown error occurred', { error });
+}

--- a/packages/schemas/src/core/index.ts
+++ b/packages/schemas/src/core/index.ts
@@ -4,6 +4,7 @@ export * from './common';
 export * from './security';
 export * from './composition';
 export * from './performance';
+export * from './errors';
 
 // Export Cloudflare environment and service utilities
 export * from './env';

--- a/packages/schemas/src/domains/organization/invites.ts
+++ b/packages/schemas/src/domains/organization/invites.ts
@@ -3,13 +3,22 @@ import { OrgIdSchema } from '../../core/identifiers';
 import { OrgInviteStatusEnum } from '../../constants/statuses';
 import { safeMessage, timestamp, createResponseSchema } from '../../core';
 
-// Re-export for backward compatibility
-export const OrgInviteStatus = OrgInviteStatusEnum;
-export type OrgInviteStatus = z.infer<typeof OrgInviteStatusEnum>;
+/**
+ * Organization Invite Schemas
+ *
+ * Schemas follow the naming convention:
+ * - Runtime validators: `*Schema` suffix
+ * - Inferred types: No suffix
+ */
 
-export const OrgInvite = z.object({
+// Status schema and type
+export const OrgInviteStatusSchema = OrgInviteStatusEnum;
+export type OrgInviteStatus = z.infer<typeof OrgInviteStatusSchema>;
+
+// Entity schema and type
+export const OrgInviteSchema = z.object({
     id: z.string().min(1, 'Invite ID is required').max(100, 'Invite ID too long'),
-    status: OrgInviteStatus,
+    status: OrgInviteStatusSchema,
     sender: OrgIdSchema,
     receiver: OrgIdSchema,
     message: safeMessage(),
@@ -17,22 +26,8 @@ export const OrgInvite = z.object({
     createdAt: timestamp(),
     updatedAt: timestamp(),
 });
-export type OrgInvite = z.infer<typeof OrgInvite>;
+export type OrgInvite = z.infer<typeof OrgInviteSchema>;
 
-// Response schemas - maintaining backward compatibility with 'invite' property
-const inviteAction = z.object({
-    success: z.literal(true),
-    invite: z.union([OrgInvite, OrgInvite.array()]),
-});
-
-const inviteError = z.object({
-    success: z.literal(false),
-    error: z.string().min(1, 'Error message is required'),
-});
-
-export const OrgInviteResponse = z.discriminatedUnion('success', [inviteAction, inviteError]);
-export type OrgInviteResponse = z.infer<typeof OrgInviteResponse>;
-
-// Alternative standardized response schema for new code
-export const OrgInviteStandardResponse = createResponseSchema(OrgInvite);
-export type OrgInviteStandardResponse = z.infer<typeof OrgInviteStandardResponse>;
+// Response schema for API boundaries (single invite or array)
+export const OrgInviteResponseSchema = createResponseSchema(z.union([OrgInviteSchema, OrgInviteSchema.array()]));
+export type OrgInviteResponse = z.infer<typeof OrgInviteResponseSchema>;


### PR DESCRIPTION
### TL;DR

Improved type safety and error handling in organization matchmaking functionality by adding runtime validation and standardized error responses.

### What changed?

- Added proper TypeScript return types to all partner-related functions
- Replaced type assertions (`as OrgInvite`) with proper schema validation using `OrgInviteSchema.parse()`
- Standardized error handling with typed error classes (e.g., `InviteNotFoundError`, `PermissionDeniedError`)
- Updated response structure to use a consistent `data` property instead of `invite`
- Added explicit validation at API boundaries to ensure data integrity
- Improved error messages to be more descriptive and consistent

### How to test?

1. Test sending, accepting, and declining organization invites through the UI
2. Verify error messages are clear when permissions are missing
3. Check that partner relationships are correctly established after accepting invites
4. Verify that toggling partnerships works correctly

### Why make this change?

This refactoring improves code reliability by ensuring data is properly validated at runtime. By adding proper TypeScript return types and schema validation, we reduce the risk of unexpected data formats causing runtime errors. The standardized error handling makes debugging easier and provides more consistent error messages to users. The change also follows best practices by validating data at API boundaries rather than assuming the correct structure.