### PR TITLE
refactor(organization-matchmaking): migrate to pnpm catalog and   centralized schemas

### DIFF
--- a/apps/organization_matchmaking/package.json
+++ b/apps/organization_matchmaking/package.json
@@ -15,16 +15,15 @@
 		"cf-typegen": "wrangler types"
 	},
 	"dependencies": {
-		"@catalyst/schema_zod": "workspace:*",
 		"@catalyst/schemas": "workspace:*"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.8.23",
-		"@cloudflare/workers-types": "^4.20250525.0",
-		"@eslint/js": "^9.25.1",
-		"@vitest/coverage-istanbul": "^3.1.4",
-		"typescript": "^5.8.3",
-		"vitest": "^3.1.4",
-		"wrangler": "^4.19.1"
+		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@eslint/js": "catalog:",
+		"@vitest/coverage-istanbul": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:",
+		"wrangler": "catalog:"
 	}
 }

--- a/apps/organization_matchmaking/src/index.ts
+++ b/apps/organization_matchmaking/src/index.ts
@@ -12,8 +12,10 @@ import {
 	InvalidUserError,
 	PermissionDeniedError,
 	CatalystError,
+	Token,
+	User,
+	OrgId,
 } from '@catalyst/schemas';
-import { Token, User, OrgId } from '@catalyst/schema_zod';
 import { Env } from './env';
 
 /**

--- a/apps/organization_matchmaking/test/index.spec.ts
+++ b/apps/organization_matchmaking/test/index.spec.ts
@@ -1,8 +1,7 @@
 // test/index.spec.ts
 import { env, runInDurableObject, SELF } from 'cloudflare:test';
 import { describe, expect, it, beforeEach } from 'vitest';
-import { OrgInvite, OrgInviteStatusSchema } from '@catalyst/schemas';
-import { User } from '@catalyst/schema_zod';
+import { OrgInvite, OrgInviteStatusSchema, User } from '@catalyst/schemas';
 
 const SENDER_ORGANIZATION = 'default';
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ catalog:
   "@chakra-ui/system": ^2.6.2
   "@chakra-ui/theme-tools": ^2.1.2
   "@cloudflare/next-on-pages": ^1.11.2
-  "@cloudflare/workers-types": ^4.20250525.0
-  "@cloudflare/vitest-pool-workers": ^0.8.23
-  "@vitest/coverage-istanbul": "^3.1.3"
+  "@cloudflare/workers-types": ^4.20251004.0
+  "@cloudflare/vitest-pool-workers": ^0.9.9
+  "@vitest/coverage-istanbul": "^3.2.4"
   "@emotion/react": ^11.11.4
   "@eslint/js": ^9.24.0
   "@flydotio/dockerfile": ^0.5.7
@@ -69,7 +69,7 @@ catalog:
   typescript: ^5.8.3
   unstorage: ^1.10.2
   uuid: ^9.0.1
-  vitest: ~3.1.0
+  vitest: ~3.2.4
   wrangler: ^4.19.1
   xml-js: ^1.6.11
   kill-port: ^2.0.1


### PR DESCRIPTION
Consolidate dependency management and schema import in org matchmaking:
      - Migrate all devDependencies to pnpm workspace catalog protocol
      - Remove legacy @catalyst/schema_zod dependency
      - Import Token, User, OrgId from centralized @catalyst/schemas
      - Ensure consistent versioning across monorepo