### PR TITLE
chore(auth): consolidate auth helpers and flatten sync route

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/validation.ts
+++ b/apps/catalyst-ui-worker/app/actions/validation.ts
@@ -1,31 +1,16 @@
 'use server';
-import { type ValidationResult, type User, getAuthzed, getCertifier, getUserCache } from '@catalyst/schemas';
-import { cookies } from 'next/headers';
-import { getCloudflareEnv } from '@/app/lib/server-utils';
+import { type ValidationResult, getAuthzed, getCertifier } from '@catalyst/schemas';
+import { getCloudflareEnv, getAuthenticatedUser } from '@/app/lib/server-utils';
 
 export async function canUserValidateChannels(): Promise<boolean> {
-    const env = getCloudflareEnv();
-
     try {
-        // Get the CF_Authorization token from cookies
-        const cfToken = (await cookies()).get('CF_Authorization')?.value;
-        if (!cfToken) {
-            return false;
-        }
-
-        // Validate the token and get user details
-        const userCache = getUserCache(env);
-        const user: User | undefined = (await userCache.getUser(cfToken)) as User | undefined;
+        const user = await getAuthenticatedUser();
         if (!user) {
             return false;
         }
 
-        // Check if user has data_channel_update permission (data custodian or admin)
-        // This checks create, update, and delete permissions
-        const authzed = getAuthzed(env);
-        const hasPermission = await authzed.canCreateUpdateDeleteDataChannel(user.orgId, user.userId);
-
-        return hasPermission;
+        const authzed = getAuthzed(getCloudflareEnv());
+        return await authzed.canCreateUpdateDeleteDataChannel(user.orgId, user.userId);
     } catch (error) {
         console.error('Failed to check user permissions:', error);
         return false;
@@ -36,17 +21,9 @@ export async function validateChannel(channelId: string, endpoint: string, organ
     const env = getCloudflareEnv();
 
     try {
-        // Get the CF_Authorization token from cookies
-        const cfToken = (await cookies()).get('CF_Authorization')?.value;
-        if (!cfToken) {
-            throw new Error('Unauthorized: No authentication token found');
-        }
-
-        // Validate the token and get user details
-        const userCache = getUserCache(env);
-        const user: User | undefined = (await userCache.getUser(cfToken)) as User | undefined;
+        const user = await getAuthenticatedUser();
         if (!user) {
-            throw new Error('Unauthorized: Invalid authentication token');
+            throw new Error('Unauthorized: Authentication required');
         }
 
         // Check if user has data_channel_update permission (data custodian or admin)

--- a/apps/catalyst-ui-worker/app/api/v1/user/sync/route.ts
+++ b/apps/catalyst-ui-worker/app/api/v1/user/sync/route.ts
@@ -1,40 +1,28 @@
-import { NextRequest } from 'next/server';
-export const dynamic = 'force-dynamic'; // defaults to auto
-import { type User, getUserCache, getAuthzed } from '@catalyst/schemas';
-import { getCloudflareEnv } from '@/app/lib/server-utils';
+export const dynamic = 'force-dynamic';
+import { getAuthzed } from '@catalyst/schemas';
+import { getCloudflareEnv, getAuthenticatedUser } from '@/app/lib/server-utils';
 
-export async function GET(request: NextRequest) {
-    // get CF token
-    const cfToken = request.cookies.get('CF_Authorization')?.value;
-    if (cfToken) {
-        // validate CF token
-        const env = getCloudflareEnv();
-        const user_cache = getUserCache(env);
-        const authxAuthzed = getAuthzed(env);
-        const user: User | undefined = (await user_cache.getUser(cfToken)) as User | undefined;
-        if (user) {
-            // user role
-            await authxAuthzed.addUserToOrg(user.orgId, user.userId);
-            // data custodian role
-            if (user.zitadelRoles.includes('data-custodian')) {
-                await authxAuthzed.addDataCustodianToOrg(user.orgId, user.userId);
-            }
-            // admin role
-            if (user.zitadelRoles.includes('org-admin')) {
-                await authxAuthzed.addAdminToOrg(user.orgId, user.userId);
-            }
-        } else {
-            return Response.json({ error: 'no user found' }, { status: 404 });
-        }
-        // Return user info WITHOUT the token
-        return Response.json({
-            userId: user.userId,
-            orgId: user.orgId,
-            roles: user.zitadelRoles,
-            isAdmin: user.zitadelRoles.includes('org-admin'),
-            isPlatformAdmin: user.zitadelRoles.includes('platform-admin'),
-        });
-    } else {
-        return Response.json({ error: 'no token found' }, { status: 401 });
+export async function GET() {
+    const user = await getAuthenticatedUser();
+    if (!user) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    // Sync user roles to authzed
+    const authzed = getAuthzed(getCloudflareEnv());
+    await authzed.addUserToOrg(user.orgId, user.userId);
+    if (user.zitadelRoles.includes('data-custodian')) {
+        await authzed.addDataCustodianToOrg(user.orgId, user.userId);
+    }
+    if (user.zitadelRoles.includes('org-admin')) {
+        await authzed.addAdminToOrg(user.orgId, user.userId);
+    }
+
+    return Response.json({
+        userId: user.userId,
+        orgId: user.orgId,
+        roles: user.zitadelRoles,
+        isAdmin: user.zitadelRoles.includes('org-admin'),
+        isPlatformAdmin: user.zitadelRoles.includes('platform-admin'),
+    });
 }

--- a/apps/catalyst-ui-worker/app/lib/server-utils.ts
+++ b/apps/catalyst-ui-worker/app/lib/server-utils.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
-import { CloudflareEnv } from '@catalyst/schemas';
+import { CloudflareEnv, getUserCache, type User } from '@catalyst/schemas';
 
 export function getCloudflareEnv(): CloudflareEnv {
     return getCloudflareContext().env as CloudflareEnv;
@@ -12,4 +12,15 @@ export async function getCFAuthorizationToken(): Promise<string> {
         throw new Error('Unauthorized: No CF_Authorization cookie found');
     }
     return token;
+}
+
+export async function getAuthenticatedUser(): Promise<User | null> {
+    let cfToken: string;
+    try {
+        cfToken = await getCFAuthorizationToken();
+    } catch {
+        return null; // No cookie present
+    }
+    const userCache = getUserCache(getCloudflareEnv());
+    return (await userCache.getUser(cfToken)) as User | null;
 }


### PR DESCRIPTION
### TL;DR

Refactored authentication logic by extracting user authentication into a reusable utility function.

### What changed?

- Added `getAuthenticatedUser()` function to `server-utils.ts` that handles CF token retrieval and user validation
- Replaced duplicate authentication code in `validation.ts` and `user/sync/route.ts` with calls to the new utility function
- Simplified error handling and removed redundant token validation logic
- Cleaned up imports by removing unused dependencies

### How to test?

1. Test channel validation permissions by accessing validation endpoints
2. Verify user sync API endpoint (`/api/v1/user/sync`) still returns correct user information
3. Confirm authentication failures return appropriate error responses
4. Check that all existing authentication flows continue to work as expected

### Why make this change?

This refactoring eliminates code duplication across authentication points, centralizes user authentication logic for better maintainability, and provides a consistent interface for retrieving authenticated users throughout the application.