### PR TITLE
feat(partners): replace global isActive toggle with per-org sharing flags

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/partners.ts
+++ b/apps/catalyst-ui-worker/app/actions/partners.ts
@@ -1,5 +1,5 @@
 'use server';
-import { getMatchmaking, OrgInvite, OrgInviteSchema } from '@catalyst/schemas';
+import { getMatchmaking, OrgInvite, OrgInviteSchema, parseStoredInvite, parseStoredInvites } from '@catalyst/schemas';
 import { getCloudflareEnv, getCFAuthorizationToken } from '@/app/lib/server-utils';
 
 export async function listInvites(): Promise<OrgInvite[]> {
@@ -9,7 +9,7 @@ export async function listInvites(): Promise<OrgInvite[]> {
     if (!result.success) {
         throw new Error(result.error);
     }
-    return OrgInviteSchema.array().parse(result.data);
+    return parseStoredInvites(result.data);
 }
 
 export type SendInviteResult = { success: true; data: OrgInvite } | { success: false; error: string };
@@ -33,7 +33,7 @@ export async function readInvite(inviteId: string): Promise<OrgInvite> {
     if (!result.success) {
         throw new Error('Reading Invite Failed');
     }
-    return OrgInviteSchema.parse(result.data);
+    return parseStoredInvite(result.data);
 }
 
 export async function declineInvite(inviteId: string): Promise<OrgInvite> {
@@ -43,7 +43,7 @@ export async function declineInvite(inviteId: string): Promise<OrgInvite> {
     if (!result.success) {
         throw new Error('Declining Invite Failed');
     }
-    return OrgInviteSchema.parse(result.data);
+    return parseStoredInvite(result.data);
 }
 
 export async function acceptInvite(inviteId: string): Promise<OrgInvite> {
@@ -54,7 +54,7 @@ export async function acceptInvite(inviteId: string): Promise<OrgInvite> {
     if (!result.success) {
         throw new Error('Accepting Invite Failed');
     }
-    return OrgInviteSchema.parse(result.data);
+    return parseStoredInvite(result.data);
 }
 
 export async function togglePartnership(inviteId: string): Promise<OrgInvite> {
@@ -64,5 +64,5 @@ export async function togglePartnership(inviteId: string): Promise<OrgInvite> {
     if (!result.success) {
         throw new Error('Toggling Partnership Failed');
     }
-    return OrgInviteSchema.parse(result.data);
+    return parseStoredInvite(result.data);
 }

--- a/apps/catalyst-ui-worker/components/partners/PartnersListComponent.tsx
+++ b/apps/catalyst-ui-worker/components/partners/PartnersListComponent.tsx
@@ -20,7 +20,6 @@ import {
     ModalHeader,
     ModalOverlay,
     Switch,
-    Tooltip,
     useDisclosure,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
@@ -118,64 +117,51 @@ export default function PartnersListComponent({
                                     headers={['Partner']}
                                     rows={partners.map((partner) => [
                                         <Box key={partner.id} data-testid={`partners-row-${partner.id}`}>
-                                            <Flex justifyContent={'space-between'}>
-                                                <OpenButton
-                                                    onClick={() =>
-                                                        router.push(
-                                                            '/partners/' +
-                                                                (partner.sender === user?.custom.org
-                                                                    ? partner.receiver
-                                                                    : partner.sender)
-                                                        )
-                                                    }
-                                                >
-                                                    {partner.sender === user?.custom.org
-                                                        ? partner.receiver
-                                                        : partner.sender}
-                                                </OpenButton>
+                                            <Flex justifyContent={'space-between'} align={'center'}>
+                                                <Box>
+                                                    <OpenButton
+                                                        onClick={() =>
+                                                            router.push(
+                                                                '/partners/' +
+                                                                    (partner.sender === user?.custom.org
+                                                                        ? partner.receiver
+                                                                        : partner.sender)
+                                                            )
+                                                        }
+                                                    >
+                                                        {partner.sender === user?.custom.org
+                                                            ? partner.receiver
+                                                            : partner.sender}
+                                                    </OpenButton>
+                                                    <PartnerSharingStatus
+                                                        partner={partner}
+                                                        currentOrg={user?.custom.org as string | undefined}
+                                                    />
+                                                </Box>
                                                 {user?.custom.isAdmin ? (
                                                     <Flex gap={10} align={'center'}>
-                                                        {(() => {
-                                                            const isDisabledByOtherOrg =
-                                                                !partner.isActive &&
-                                                                partner.disabledBy !== null &&
-                                                                partner.disabledBy !== user?.custom.org;
-                                                            return (
-                                                                <Tooltip
-                                                                    hasArrow
-                                                                    label={
-                                                                        isDisabledByOtherOrg
-                                                                            ? `Only ${partner.disabledBy} can re-enable this partnership`
-                                                                            : undefined
-                                                                    }
-                                                                    isDisabled={!isDisabledByOtherOrg}
-                                                                >
-                                                                    <Box as="span">
-                                                                        <Switch
-                                                                            data-testid={`partners-row-${partner.id}-toggle`}
-                                                                            colorScheme="green"
-                                                                            isChecked={partner.isActive}
-                                                                            isDisabled={
-                                                                                togglingId === partner.id ||
-                                                                                isDisabledByOtherOrg
-                                                                            }
-                                                                            onChange={() => {
-                                                                                setTogglingId(partner.id);
-                                                                                togglePartnership(partner.id)
-                                                                                    .then(fetchInvites)
-                                                                                    .catch(() => {
-                                                                                        setHasError(true);
-                                                                                        setErrorMessage(
-                                                                                            'An error occurred while toggling the partner. Please try again later.'
-                                                                                        );
-                                                                                    })
-                                                                                    .finally(() => setTogglingId(null));
-                                                                            }}
-                                                                        />
-                                                                    </Box>
-                                                                </Tooltip>
-                                                            );
-                                                        })()}
+                                                        <Switch
+                                                            data-testid={`partners-row-${partner.id}-toggle`}
+                                                            colorScheme="green"
+                                                            isChecked={
+                                                                partner.sender === user?.custom.org
+                                                                    ? partner.senderEnabled
+                                                                    : partner.receiverEnabled
+                                                            }
+                                                            isDisabled={togglingId === partner.id}
+                                                            onChange={() => {
+                                                                setTogglingId(partner.id);
+                                                                togglePartnership(partner.id)
+                                                                    .then(fetchInvites)
+                                                                    .catch(() => {
+                                                                        setHasError(true);
+                                                                        setErrorMessage(
+                                                                            'An error occurred while toggling the partner. Please try again later.'
+                                                                        );
+                                                                    })
+                                                                    .finally(() => setTogglingId(null));
+                                                            }}
+                                                        />
                                                         <TrashButton
                                                             data-testid={`partners-row-${partner.id}-delete`}
                                                             onClick={() => {
@@ -254,6 +240,18 @@ export default function PartnersListComponent({
         </ListView>
     );
 }
+
+const PartnerSharingStatus = ({ partner, currentOrg }: { partner: OrgInvite; currentOrg?: string }) => {
+    const isSender = partner.sender === currentOrg;
+    const partnerIsSharing = isSender ? partner.receiverEnabled : partner.senderEnabled;
+    const partnerName = isSender ? partner.receiver : partner.sender;
+
+    return (
+        <Text fontSize="xs" color={partnerIsSharing ? 'green.500' : 'gray.500'} mt={1}>
+            {partnerIsSharing ? `${partnerName} is sharing with you` : `${partnerName} is not sharing with you`}
+        </Text>
+    );
+};
 
 const OrgInviteMessage = ({ invite, org }: { invite: OrgInvite; org: string }) => (
     <Text>

--- a/apps/catalyst-ui-worker/test/e2e/partners.toggle.spec.ts
+++ b/apps/catalyst-ui-worker/test/e2e/partners.toggle.spec.ts
@@ -6,30 +6,40 @@ import { cleanupPartnershipState, createAndAcceptPartnership } from './utils/par
 /**
  * Partnership Toggle E2E Tests
  *
- * Validates the  partnership toggle flow through the UI:
- * - Bidirectional toggle consistency (both orgs see the same state)
+ * Validates the per-org partnership toggle flow through the UI:
+ * - Independent per-org toggle (each org controls their own sharing flag)
+ * - PartnerSharingStatus text reflects partner's sharing direction
+ * - Both-orgs-sharing mutual state
+ * - Receiver-side toggle perspective
  * - Controlled Switch (isChecked reflects server state, not local state)
- * - Tug-of-war prevention (non-disabling org cannot re-enable)
- * - Review fix 4: isDisabled during in-flight toggle request
+ * - isDisabled during in-flight toggle request
+ * - Toggle API failure shows error in UI
  *
  */
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 /**
+ * Locate the partner row for a given org name.
+ * Asserts exactly 1 matching row exists — fails fast if cleanup missed stale entries.
+ */
+async function getPartnerRow(page: Page, partnerOrgName: string) {
+    const rows = page
+        .getByTestId(PARTNERS.LIST_CARD)
+        .locator('[data-testid^="partners-row-"]')
+        .filter({ hasText: partnerOrgName });
+
+    await expect(rows).toHaveCount(1);
+    return rows.first();
+}
+
+/**
  * Get the toggle Switch for a partner row by org name.
  * Partner IDs are dynamic, so we locate the row by text content.
  */
-function getPartnerToggle(page: Page, partnerOrgName: string) {
-    // Use .last() to select the most recently created partnership entry.
-    // The DO may retain stale cross-org entries that survive cleanup due to
-    // eventual consistency; .last() ensures we operate on the current entry.
-    const partnerRow = page
-        .getByTestId(PARTNERS.LIST_CARD)
-        .locator('[data-testid^="partners-row-"]')
-        .filter({ hasText: partnerOrgName })
-        .last();
-    return partnerRow.locator('[data-testid*="-toggle"]');
+async function getPartnerToggle(page: Page, partnerOrgName: string) {
+    const row = await getPartnerRow(page, partnerOrgName);
+    return row.locator('[data-testid*="-toggle"]');
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -45,7 +55,7 @@ test.describe('Partnership Toggle Bug Fixes', () => {
         );
     });
 
-    test('Bidirectional toggle consistency and tug-of-war prevention', async ({
+    test('Independent per-org toggle with sharing status', async ({
         orgAdminPage: alphaPage,
         orgAdminBetaPage: betaPage,
     }) => {
@@ -57,10 +67,10 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await createAndAcceptPartnership(alphaPage, betaPage);
         });
 
-        // Partnerships start with isActive: false after acceptance
-        await test.step('Step 2: Alpha activates partnership (toggle ON)', async () => {
+        // Both senderEnabled and receiverEnabled start false after acceptance
+        await test.step('Step 2: Alpha toggles ON', async () => {
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).toBeVisible();
             await expect(toggle).not.toBeChecked();
@@ -69,61 +79,112 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await expect(toggle).toBeChecked();
         });
 
-        await test.step('Step 3: Beta sees partnership as ON', async () => {
+        await test.step('Step 3: Beta toggle is still unchecked (independent)', async () => {
             await betaPage.goto('/partners');
-            const toggle = getPartnerToggle(betaPage, 'test-org-alpha');
+            const toggle = await getPartnerToggle(betaPage, 'test-org-alpha');
+
+            await expect(toggle).toBeVisible();
+            await expect(toggle).not.toBeChecked();
+        });
+
+        // HIGH coverage gap: validate PartnerSharingStatus text
+        await test.step('Step 3b: Beta sees that Alpha is sharing', async () => {
+            const row = await getPartnerRow(betaPage, 'test-org-alpha');
+            await expect(row).toContainText('test-org-alpha is sharing with you');
+        });
+
+        await test.step('Step 4: Beta toggles ON', async () => {
+            const toggle = await getPartnerToggle(betaPage, 'test-org-alpha');
+            await toggle.click();
+            await expect(toggle).toBeChecked();
+        });
+
+        // HIGH coverage gap: both-orgs-sharing mutual state
+        await test.step('Step 4b: Alpha sees both sharing (mutual state)', async () => {
+            await alphaPage.goto('/partners');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
+            await expect(toggle).toBeChecked();
+
+            const row = await getPartnerRow(alphaPage, 'test-org-beta');
+            await expect(row).toContainText('test-org-beta is sharing with you');
+        });
+
+        await test.step('Step 5: Alpha toggle still checked (independent)', async () => {
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).toBeVisible();
             await expect(toggle).toBeChecked();
         });
 
-        await test.step('Step 4: Alpha toggles partnership OFF', async () => {
+        await test.step('Step 6: Alpha toggles OFF', async () => {
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
+            await toggle.click();
+            await expect(toggle).not.toBeChecked();
+        });
+
+        // HIGH coverage gap: status text shows "not sharing" after toggle off
+        await test.step('Step 6b: Alpha sees Beta is still sharing', async () => {
+            const row = await getPartnerRow(alphaPage, 'test-org-beta');
+            await expect(row).toContainText('test-org-beta is sharing with you');
+        });
+
+        await test.step('Step 7: Beta toggle still checked (independent)', async () => {
+            await betaPage.goto('/partners');
+            const toggle = await getPartnerToggle(betaPage, 'test-org-alpha');
+
+            await expect(toggle).toBeVisible();
+            await expect(toggle).toBeChecked();
+        });
+
+        await test.step('Step 7b: Beta sees Alpha is no longer sharing', async () => {
+            const row = await getPartnerRow(betaPage, 'test-org-alpha');
+            await expect(row).toContainText('test-org-alpha is not sharing with you');
+        });
+
+        await test.step('Cleanup: delete partnership from both sides', async () => {
+            await cleanupPartnershipState(alphaPage, betaPage);
+        });
+    });
+
+    // MEDIUM coverage gap: receiver-side toggle perspective
+    test('Receiver-side toggle perspective', async ({ orgAdminPage: alphaPage, orgAdminBetaPage: betaPage }) => {
+        await test.step('Setup: Create partnership', async () => {
+            await cleanupPartnershipState(alphaPage, betaPage);
+            await createAndAcceptPartnership(alphaPage, betaPage);
+        });
+
+        await test.step('Step 1: Beta (receiver) toggles ON', async () => {
+            await betaPage.goto('/partners');
+            const toggle = await getPartnerToggle(betaPage, 'test-org-alpha');
+
+            await expect(toggle).not.toBeChecked();
+            await toggle.click();
+            await expect(toggle).toBeChecked();
+        });
+
+        await test.step('Step 2: Alpha sees Beta is sharing', async () => {
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const row = await getPartnerRow(alphaPage, 'test-org-beta');
+            await expect(row).toContainText('test-org-beta is sharing with you');
+
+            // Alpha's own toggle should still be off
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
+            await expect(toggle).not.toBeChecked();
+        });
+
+        await test.step('Step 3: Beta (receiver) toggles OFF', async () => {
+            await betaPage.goto('/partners');
+            const toggle = await getPartnerToggle(betaPage, 'test-org-alpha');
 
             await expect(toggle).toBeChecked();
             await toggle.click();
             await expect(toggle).not.toBeChecked();
         });
 
-        await test.step('Step 5: Beta sees partnership as OFF', async () => {
-            await betaPage.goto('/partners');
-            const toggle = getPartnerToggle(betaPage, 'test-org-alpha');
-
-            await expect(toggle).toBeVisible();
-            await expect(toggle).not.toBeChecked();
-        });
-
-        await test.step('Step 6: Beta cannot re-enable (tug-of-war prevention)', async () => {
-            const toggle = getPartnerToggle(betaPage, 'test-org-alpha');
-
-            // Toggle should be disabled — Beta cannot re-enable what Alpha disabled
-            await expect(toggle).toBeDisabled();
-            await expect(toggle).not.toBeChecked();
-
-            // Hover over the toggle's wrapper to trigger the tooltip
-            await toggle.hover();
-            const tooltip = betaPage.getByText('Only test-org-alpha can re-enable this partnership');
-            await expect(tooltip).toBeVisible({ timeout: 5000 });
-        });
-
-        await test.step('Step 7: Alpha re-enables the partnership', async () => {
+        await test.step('Step 4: Alpha sees Beta is no longer sharing', async () => {
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
-
-            await expect(toggle).toBeVisible();
-            await expect(toggle).not.toBeChecked();
-
-            await toggle.click();
-            await expect(toggle).toBeChecked();
-        });
-
-        await test.step('Step 8: Beta sees partnership as ON', async () => {
-            await betaPage.goto('/partners');
-            const toggle = getPartnerToggle(betaPage, 'test-org-alpha');
-
-            await expect(toggle).toBeVisible();
-            await expect(toggle).toBeChecked();
+            const row = await getPartnerRow(alphaPage, 'test-org-beta');
+            await expect(row).toContainText('test-org-beta is not sharing with you');
         });
 
         await test.step('Cleanup: delete partnership from both sides', async () => {
@@ -140,10 +201,10 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await createAndAcceptPartnership(alphaPage, betaPage);
         });
 
-        // Partnerships start with isActive: false after acceptance
+        // Both senderEnabled and receiverEnabled start false after acceptance
         await test.step('Step 1: Verify initial toggle state', async () => {
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).toBeVisible();
             await expect(toggle).not.toBeChecked();
@@ -157,7 +218,7 @@ test.describe('Partnership Toggle Bug Fixes', () => {
                 await route.continue();
             });
 
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
             await toggle.click();
 
             // Toggle should be disabled while the request is in-flight
@@ -165,7 +226,7 @@ test.describe('Partnership Toggle Bug Fixes', () => {
         });
 
         await test.step('Step 3: Wait for toggle to complete', async () => {
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             // Wait for the toggle to become enabled again (request completed)
             await expect(toggle).not.toBeDisabled({ timeout: 10000 });
@@ -174,7 +235,7 @@ test.describe('Partnership Toggle Bug Fixes', () => {
         });
 
         await test.step('Step 4: Toggle back and verify same disabled pattern', async () => {
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
             await toggle.click();
 
             // Should be disabled during the request again
@@ -200,10 +261,10 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await createAndAcceptPartnership(alphaPage, betaPage);
         });
 
-        // Partnerships start with isActive: false after acceptance
+        // Both senderEnabled and receiverEnabled start false after acceptance
         await test.step('Step 1: Alpha toggles partnership ON', async () => {
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).not.toBeChecked();
             await toggle.click();
@@ -215,14 +276,14 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await expect(alphaPage).toHaveURL('/channels');
 
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).toBeVisible();
             await expect(toggle).toBeChecked();
         });
 
         await test.step('Step 3: Alpha toggles partnership OFF', async () => {
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
             await toggle.click();
             await expect(toggle).not.toBeChecked();
         });
@@ -232,13 +293,57 @@ test.describe('Partnership Toggle Bug Fixes', () => {
             await expect(alphaPage).toHaveURL('/channels');
 
             await alphaPage.goto('/partners');
-            const toggle = getPartnerToggle(alphaPage, 'test-org-beta');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
 
             await expect(toggle).toBeVisible();
             await expect(toggle).not.toBeChecked();
         });
 
         await test.step('Cleanup: delete partnership from both sides', async () => {
+            await cleanupPartnershipState(alphaPage, betaPage);
+        });
+    });
+
+    // MEDIUM coverage gap: toggle API failure shows error UI
+    test('Toggle API failure shows error in UI', async ({ orgAdminPage: alphaPage, orgAdminBetaPage: betaPage }) => {
+        await test.step('Setup: Create partnership', async () => {
+            await cleanupPartnershipState(alphaPage, betaPage);
+            await createAndAcceptPartnership(alphaPage, betaPage);
+        });
+
+        await test.step('Step 1: Intercept toggle API to return error', async () => {
+            await alphaPage.goto('/partners');
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
+            await expect(toggle).toBeVisible();
+
+            // Force the server action to throw by intercepting the Next.js RSC call
+            await alphaPage.route('**/partners', async (route) => {
+                const request = route.request();
+                // Only intercept the server action POST (Next.js RSC), not navigation GETs
+                if (request.method() === 'POST') {
+                    await route.fulfill({
+                        status: 500,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ error: 'Internal Server Error' }),
+                    });
+                } else {
+                    await route.continue();
+                }
+            });
+        });
+
+        await test.step('Step 2: Click toggle and verify error is displayed', async () => {
+            const toggle = await getPartnerToggle(alphaPage, 'test-org-beta');
+            await toggle.click();
+
+            // The component catches errors and shows an ErrorCard with this message
+            await expect(
+                alphaPage.getByText('An error occurred while toggling the partner. Please try again later.')
+            ).toBeVisible({ timeout: 10000 });
+        });
+
+        await test.step('Cleanup: remove route interceptor and delete partnership', async () => {
+            await alphaPage.unroute('**/partners');
             await cleanupPartnershipState(alphaPage, betaPage);
         });
     });

--- a/apps/organization_matchmaking/src/index.ts
+++ b/apps/organization_matchmaking/src/index.ts
@@ -1,6 +1,7 @@
 import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers';
 import {
 	OrgInviteStoredResponseSchema,
+	parseStoredInvite,
 	OrgInvite,
 	OrgInviteStatusSchema,
 	OrgInviteStatus,
@@ -18,6 +19,21 @@ import {
 	OrgIdSchema,
 } from '@catalyst/schemas';
 import { Env } from './env';
+
+function parseMailbox(raw: unknown): OrgInvite[] {
+	if (!Array.isArray(raw)) return [];
+	return raw.map((item) => parseStoredInvite(item));
+}
+
+function clientErrorMessage(error: unknown): string {
+	if (error instanceof CatalystError) return error.message;
+	// Errors thrown inside blockConcurrencyWhile or across the DO-Worker RPC boundary
+	// lose their CatalystError prototype but retain the original message.
+	if (error instanceof Error && error.message.startsWith('CatalystError:')) {
+		return error.message.replace(/^CatalystError:\s*/, '');
+	}
+	return 'An internal error occurred';
+}
 
 /*
 	when an invite is created it is set to pending
@@ -40,15 +56,15 @@ export class OrganizationMatchmakingDO extends DurableObject {
 			receiver,
 			status: 'pending',
 			message,
-			isActive: false,
-			disabledBy: null,
+			senderEnabled: false,
+			receiverEnabled: false,
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 		};
 
 		await this.ctx.blockConcurrencyWhile(async () => {
-			const senderMailbox = (await this.ctx.storage.get<OrgInvite[]>(sender)) ?? [];
-			const receiverMailbox = (await this.ctx.storage.get<OrgInvite[]>(receiver)) ?? [];
+			const senderMailbox = parseMailbox(await this.ctx.storage.get(sender));
+			const receiverMailbox = parseMailbox(await this.ctx.storage.get(receiver));
 
 			// BIDIRECTIONAL CHECK: Only one pending invite allowed between any org pair
 			// Check if sender already has a pending invite TO receiver
@@ -78,8 +94,7 @@ export class OrganizationMatchmakingDO extends DurableObject {
 	}
 
 	async list(orgId: OrgId): Promise<OrgInvite[]> {
-		const mailbox = (await this.ctx.storage.get<OrgInvite[]>(orgId)) ?? [];
-		return mailbox;
+		return parseMailbox(await this.ctx.storage.get(orgId));
 	}
 
 	/**
@@ -90,7 +105,7 @@ export class OrganizationMatchmakingDO extends DurableObject {
 	 * @throws {InviteNotFoundError} If invite is not found
 	 */
 	async read(orgId: OrgId, inviteId: string): Promise<OrgInvite> {
-		const mailbox = (await this.ctx.storage.get<OrgInvite[]>(orgId)) ?? [];
+		const mailbox = parseMailbox(await this.ctx.storage.get(orgId));
 		const invite = mailbox.find((inv) => inv.id === inviteId);
 
 		if (!invite) {
@@ -101,23 +116,79 @@ export class OrganizationMatchmakingDO extends DurableObject {
 	}
 
 	/**
-	 * Toggles the active status of a partnership invite between organizations.
+	 * Toggles the caller's data-sharing flag on a partnership invite.
+	 * If the caller is the sender, flips `senderEnabled`.
+	 * If the caller is the receiver, flips `receiverEnabled`.
 	 *
-	 * @param orgId - The ID of the organization whose mailbox contains the invite
+	 * @param orgId - The ID of the organization toggling their sharing
 	 * @param inviteId - The unique identifier of the invite to toggle
 	 * @returns The updated invite
 	 * @throws {InviteNotFoundError} If invite is not found in either mailbox
-	 *
-	 * @example
-	 * ```typescript
-	 * const invite = await durableObject.togglePartnership('org-123', 'invite-456');
-	 * console.log('Invite status toggled:', invite.isActive);
-	 * ```
 	 */
 	async togglePartnership(orgId: OrgId, inviteId: string): Promise<OrgInvite> {
 		// Pre-validate outside blockConcurrencyWhile to avoid durableObjectReset on expected errors.
-		// Throwing inside blockConcurrencyWhile resets the DO's in-memory state.
-		const orgMailbox = (await this.ctx.storage.get<OrgInvite[]>(orgId)) ?? [];
+		const orgMailbox = parseMailbox(await this.ctx.storage.get(orgId));
+		const invite = orgMailbox.find((inv) => inv.id === inviteId);
+
+		if (!invite) {
+			throw new InviteNotFoundError(inviteId);
+		}
+
+		const otherOrg = invite.sender === orgId ? invite.receiver : invite.sender;
+		const otherMailbox = parseMailbox(await this.ctx.storage.get(otherOrg));
+
+		if (!otherMailbox.find((inv) => inv.id === inviteId)) {
+			throw new InviteNotFoundError(inviteId);
+		}
+
+		// Mutation inside blockConcurrencyWhile with fresh reads for atomicity.
+		let updatedInvite!: OrgInvite;
+
+		await this.ctx.blockConcurrencyWhile(async () => {
+			const freshOrgMailbox = parseMailbox(await this.ctx.storage.get(orgId));
+			const freshOtherMailbox = parseMailbox(await this.ctx.storage.get(otherOrg));
+			const freshInvite = freshOrgMailbox.find((inv) => inv.id === inviteId);
+
+			if (!freshInvite) {
+				throw new InviteNotFoundError(inviteId);
+			}
+
+			if (freshInvite.status !== 'accepted') {
+				throw new InvalidOperationError('Can only toggle accepted partnerships');
+			}
+
+			const isSender = freshInvite.sender === orgId;
+
+			if (isSender) {
+				updatedInvite = { ...freshInvite, senderEnabled: !freshInvite.senderEnabled, updatedAt: Date.now() };
+			} else {
+				updatedInvite = {
+					...freshInvite,
+					receiverEnabled: !freshInvite.receiverEnabled,
+					updatedAt: Date.now(),
+				};
+			}
+
+			await this.ctx.storage.put(
+				orgId,
+				freshOrgMailbox.map((inv) => (inv.id === inviteId ? updatedInvite : inv))
+			);
+			await this.ctx.storage.put(
+				otherOrg,
+				freshOtherMailbox.map((inv) => (inv.id === inviteId ? updatedInvite : inv))
+			);
+		});
+
+		return updatedInvite;
+	}
+
+	async setPartnershipFlags(
+		orgId: OrgId,
+		inviteId: string,
+		senderEnabled: boolean,
+		receiverEnabled: boolean
+	): Promise<OrgInvite> {
+		const orgMailbox = parseMailbox(await this.ctx.storage.get(orgId));
 		const invite = orgMailbox.find((inv) => inv.id === inviteId);
 
 		if (!invite) {
@@ -125,39 +196,23 @@ export class OrganizationMatchmakingDO extends DurableObject {
 		}
 
 		if (invite.status !== 'accepted') {
-			throw new InvalidOperationError('Can only toggle accepted partnerships');
+			throw new InvalidOperationError('Can only set flags on accepted partnerships');
 		}
 
 		const otherOrg = invite.sender === orgId ? invite.receiver : invite.sender;
-		const otherMailbox = (await this.ctx.storage.get<OrgInvite[]>(otherOrg)) ?? [];
 
-		if (!otherMailbox.find((inv) => inv.id === inviteId)) {
-			throw new InviteNotFoundError(inviteId);
-		}
-
-		if (!invite.isActive && invite.disabledBy !== null && invite.disabledBy !== orgId) {
-			throw new InvalidOperationError('Only the organization that disabled this partnership can re-enable it');
-		}
-
-		// Mutation inside blockConcurrencyWhile with fresh reads for atomicity.
-		// The pre-validation above is a fast-reject gate; the critical section
-		// re-reads storage so it never writes against stale data.
 		let updatedInvite!: OrgInvite;
 
 		await this.ctx.blockConcurrencyWhile(async () => {
-			const freshOrgMailbox = (await this.ctx.storage.get<OrgInvite[]>(orgId)) ?? [];
-			const freshOtherMailbox = (await this.ctx.storage.get<OrgInvite[]>(otherOrg)) ?? [];
+			const freshOrgMailbox = parseMailbox(await this.ctx.storage.get(orgId));
+			const freshOtherMailbox = parseMailbox(await this.ctx.storage.get(otherOrg));
 			const freshInvite = freshOrgMailbox.find((inv) => inv.id === inviteId);
 
 			if (!freshInvite) {
 				throw new InviteNotFoundError(inviteId);
 			}
 
-			if (freshInvite.isActive) {
-				updatedInvite = { ...freshInvite, isActive: false, disabledBy: orgId, updatedAt: Date.now() };
-			} else {
-				updatedInvite = { ...freshInvite, isActive: true, disabledBy: null, updatedAt: Date.now() };
-			}
+			updatedInvite = { ...freshInvite, senderEnabled, receiverEnabled, updatedAt: Date.now() };
 
 			await this.ctx.storage.put(
 				orgId,
@@ -176,7 +231,7 @@ export class OrganizationMatchmakingDO extends DurableObject {
 		// Validate external input at boundary
 		const validatedStatus = OrgInviteStatusSchema.parse(status);
 
-		const responder = (await this.ctx.storage.get<OrgInvite[]>(orgId)) ?? [];
+		const responder = parseMailbox(await this.ctx.storage.get(orgId));
 
 		const invite = responder.find((inv) => inv.id === inviteId);
 
@@ -186,7 +241,7 @@ export class OrganizationMatchmakingDO extends DurableObject {
 
 		const otherOrg = invite.sender === orgId ? invite.receiver : invite.sender;
 
-		const otherMailbox = (await this.ctx.storage.get<OrgInvite[]>(otherOrg)) ?? [];
+		const otherMailbox = parseMailbox(await this.ctx.storage.get(otherOrg));
 
 		if (!otherMailbox.find((inv) => inv.id === inviteId)) {
 			throw new InviteNotFoundError(inviteId);
@@ -255,12 +310,7 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			// Validate error response
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}
@@ -287,32 +337,56 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			const id = this.env.ORG_MATCHMAKING.idFromName(doNamespace);
 			const stub = this.env.ORG_MATCHMAKING.get(id);
 
+			const preToggle = await stub.read(user.orgId, inviteId);
 			const invite = await stub.togglePartnership(user.orgId, inviteId);
 
-			const partner = user.orgId === invite.sender ? invite.receiver : invite.sender;
+			const isSender = user.orgId === invite.sender;
 
-			if (invite.isActive) {
-				await Promise.all([
-					this.env.AUTHZED.addPartnerToOrg(user.orgId, partner),
-					this.env.AUTHZED.addPartnerToOrg(partner, user.orgId),
-				]);
-			} else {
-				await Promise.all([
-					this.env.AUTHZED.deletePartnerInOrg(user.orgId, partner),
-					this.env.AUTHZED.deletePartnerInOrg(partner, user.orgId),
-				]);
+			// Unidirectional: addPartnerToOrg(sharer, reader) means reader can see sharer's data
+			try {
+				if (isSender) {
+					if (invite.senderEnabled) {
+						await this.env.AUTHZED.addPartnerToOrg(invite.sender, invite.receiver);
+					} else {
+						await this.env.AUTHZED.deletePartnerInOrg(invite.sender, invite.receiver);
+					}
+				} else {
+					if (invite.receiverEnabled) {
+						await this.env.AUTHZED.addPartnerToOrg(invite.receiver, invite.sender);
+					} else {
+						await this.env.AUTHZED.deletePartnerInOrg(invite.receiver, invite.sender);
+					}
+				}
+			} catch (spiceDbError) {
+				// Rollback only the caller's flag — preserve the other org's flag from the
+				// post-toggle invite to avoid overwriting a concurrent partner's toggle.
+				try {
+					await stub.setPartnershipFlags(
+						user.orgId,
+						inviteId,
+						isSender ? preToggle.senderEnabled : invite.senderEnabled,
+						isSender ? invite.receiverEnabled : preToggle.receiverEnabled
+					);
+				} catch (rollbackError) {
+					console.error('[togglePartnership] rollback failed', {
+						inviteId,
+						orgId: user.orgId,
+						original: spiceDbError instanceof Error ? spiceDbError.message : 'Unknown',
+						rollback: rollbackError instanceof Error ? rollbackError.message : 'Unknown',
+					});
+				}
+				throw spiceDbError;
 			}
 
 			return OrgInviteStoredResponseSchema.parse({ success: true, data: invite });
 		} catch (error) {
+			console.error('[togglePartnership] failed', {
+				inviteId,
+				error: error instanceof Error ? error.message : 'Unknown',
+			});
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}
@@ -360,12 +434,7 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			// Validate error response
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}
@@ -389,10 +458,7 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			const stub = this.env.ORG_MATCHMAKING.get(id);
 			const invite = await stub.respond(user.orgId, inviteId, 'accepted');
 
-			await Promise.all([
-				this.env.AUTHZED.addPartnerToOrg(invite.sender, invite.receiver),
-				this.env.AUTHZED.addPartnerToOrg(invite.receiver, invite.sender),
-			]);
+			// No SpiceDB calls on accept — data sharing is controlled per-org via toggle
 
 			// Validate response at Worker boundary
 			return OrgInviteResponseSchema.parse({ success: true, data: invite });
@@ -400,12 +466,7 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			// Validate error response
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}
@@ -429,23 +490,33 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			const stub = this.env.ORG_MATCHMAKING.get(id);
 			const invite = await stub.respond(user.orgId, inviteId, 'declined');
 
-			await Promise.all([
-				this.env.AUTHZED.deletePartnerInOrg(invite.sender, invite.receiver),
-				this.env.AUTHZED.deletePartnerInOrg(invite.receiver, invite.sender),
-			]);
+			// Unconditionally delete both directions — deletePartnerInOrg is idempotent.
+			// DO deletion is the source of truth; SpiceDB failure is logged but not fatal.
+			try {
+				await Promise.all([
+					this.env.AUTHZED.deletePartnerInOrg(invite.sender, invite.receiver),
+					this.env.AUTHZED.deletePartnerInOrg(invite.receiver, invite.sender),
+				]);
+			} catch (spiceDbError) {
+				console.error('[declineInvite] SpiceDB cleanup failed', {
+					inviteId,
+					sender: invite.sender,
+					receiver: invite.receiver,
+					error: spiceDbError instanceof Error ? spiceDbError.message : 'Unknown',
+				});
+			}
 
 			// Validate response at Worker boundary
 			return OrgInviteResponseSchema.parse({ success: true, data: invite });
 		} catch (error) {
+			console.error('[declineInvite] failed', {
+				inviteId,
+				error: error instanceof Error ? error.message : 'Unknown',
+			});
 			// Validate error response
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}
@@ -475,12 +546,7 @@ export default class OrganizationMatchmakingWorker extends WorkerEntrypoint<Env>
 			// Validate error response
 			return OrgInviteResponseSchema.parse({
 				success: false,
-				error:
-					error instanceof CatalystError
-						? error.message
-						: error instanceof Error
-							? error.message
-							: 'Unknown error',
+				error: clientErrorMessage(error),
 			});
 		}
 	}

--- a/apps/organization_matchmaking/test/index.spec.ts
+++ b/apps/organization_matchmaking/test/index.spec.ts
@@ -1,7 +1,7 @@
 // test/index.spec.ts
 import { env, runInDurableObject, SELF } from 'cloudflare:test';
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { OrgInvite, OrgInviteStatusSchema, User } from '@catalyst/schemas';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { OrgInvite, OrgInviteStatusSchema, OrgInviteStoredSchema, User } from '@catalyst/schemas';
 
 const SENDER_ORGANIZATION = 'default';
 
@@ -10,6 +10,27 @@ const SENDER_ORGANIZATION = 'default';
  * @param appendCount - The number of invites to append to the existing invites
  * @returns A list of invites
  */
+function createOldFormatInvite(overrides: {
+	id?: string;
+	sender: string;
+	receiver: string;
+	status?: string;
+	isActive: boolean;
+	disabledBy?: string | null;
+}) {
+	return {
+		id: overrides.id ?? `old-invite-${crypto.randomUUID().slice(0, 8)}`,
+		status: overrides.status ?? 'accepted',
+		sender: overrides.sender,
+		receiver: overrides.receiver,
+		message: 'legacy invite',
+		isActive: overrides.isActive,
+		disabledBy: overrides.disabledBy ?? null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
 function generateInvites(maxCount?: number) {
 	// one pending and one accepted
 	// offset by 7 and 10 days respectively
@@ -31,8 +52,8 @@ function generateInvites(maxCount?: number) {
 			sender: 'default',
 			receiver: `test-receiver-org-${i + 1}`,
 			message: `test-message ${i + 1}`,
-			isActive: true,
-			disabledBy: null,
+			senderEnabled: false,
+			receiverEnabled: false,
 			createdAt: now + daysOffset * 24 * 60 * 60 * 1000 + hoursOffset * 60 * 60 * 1000,
 			updatedAt: now + daysOffset * 24 * 60 * 60 * 1000 + hoursOffset * 60 * 60 * 1000,
 		};
@@ -249,10 +270,12 @@ describe('organization matchmaking worker', () => {
 		);
 		expect(acceptedInvite.status).toBe('accepted');
 
+		// Sender toggles their sharing on
 		const toggledInvite: OrgInvite = await stub.togglePartnership('default', createdInvite.id);
 
-		// validate that the invite is toggled (starts inactive after accept, toggles to active)
-		expect(toggledInvite.isActive).toBe(!acceptedInvite.isActive);
+		// Sender's flag flipped, receiver's unchanged
+		expect(toggledInvite.senderEnabled).toBe(true);
+		expect(toggledInvite.receiverEnabled).toBe(false);
 	});
 
 	it('should return appropriate error when invite is not found', async () => {
@@ -347,12 +370,13 @@ describe('organization matchmaking worker', () => {
 		// Get the invite from both mailboxes before toggle
 		const senderReadInvite: OrgInvite = await stub.read(invites[1].sender, sentInvites[1].id);
 		const receiverReadInvite: OrgInvite = await stub.read(invites[1].receiver, sentInvites[1].id);
-		expect(senderReadInvite.isActive).toBe(false);
-		expect(receiverReadInvite.isActive).toBe(false);
+		expect(senderReadInvite.senderEnabled).toBe(false);
+		expect(receiverReadInvite.senderEnabled).toBe(false);
 
-		// Toggle the invite
+		// Sender toggles their sharing on for the second invite
 		const toggledInvite: OrgInvite = await stub.togglePartnership(invites[1].sender, sentInvites[1].id);
-		expect(toggledInvite.isActive).toBe(true);
+		expect(toggledInvite.senderEnabled).toBe(true);
+		expect(toggledInvite.receiverEnabled).toBe(false);
 
 		// Verify the toggle in sender's mailbox (has all 3 invites)
 		const senderMailboxInvites: OrgInvite[] = await stub.list(invites[1].sender);
@@ -361,16 +385,16 @@ describe('organization matchmaking worker', () => {
 		// Check that only the target invite was updated
 		for (const invite of senderMailboxInvites) {
 			if (invite.id === sentInvites[1].id) {
-				expect(invite.isActive).toBe(true);
+				expect(invite.senderEnabled).toBe(true);
 			} else {
-				expect(invite.isActive).toBe(false);
+				expect(invite.senderEnabled).toBe(false);
 			}
 		}
 
 		// Verify in receiver's mailbox (has only 1 invite)
 		const receiverMailboxInvites: OrgInvite[] = await stub.list(invites[1].receiver);
 		expect(receiverMailboxInvites.length).toBe(1);
-		expect(receiverMailboxInvites[0].isActive).toBe(true);
+		expect(receiverMailboxInvites[0].senderEnabled).toBe(true);
 	});
 
 	it('should return error when invite not found in respond', async () => {
@@ -599,9 +623,10 @@ describe('organization matchmaking worker', () => {
 				throw new Error('Failed to toggle invite');
 			}
 
-			// Verify the toggle (starts false after accept, toggles to true)
+			// Verify the toggle — sender toggled, so senderEnabled flipped to true
 			const toggledInvite = response.data as OrgInvite;
-			expect(toggledInvite.isActive).toBe(true);
+			expect(toggledInvite.senderEnabled).toBe(true);
+			expect(toggledInvite.receiverEnabled).toBe(false);
 		});
 
 		it('should return error when token is missing', async () => {
@@ -705,12 +730,11 @@ describe('organization matchmaking worker', () => {
 		}
 	});
 
-	// Bug 5: Tug of war — only the disabling org can re-enable
-	it('should prevent other org from re-enabling a disabled partnership', async () => {
+	// Per-org toggle: sender toggle only flips senderEnabled
+	it('should only flip senderEnabled when sender toggles', async () => {
 		const id = env.ORG_MATCHMAKING.idFromName('default');
 		const stub = env.ORG_MATCHMAKING.get(id);
 
-		// clear the storage
 		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
@@ -722,40 +746,89 @@ describe('organization matchmaking worker', () => {
 			inviteToSend.message
 		);
 
-		// Accept the invite (receiver accepts)
 		await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
 
-		// Sender enables the partnership
-		const enabledInvite: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
-		expect(enabledInvite.isActive).toBe(true);
-		expect(enabledInvite.disabledBy).toBeNull();
+		// Sender enables sharing
+		const afterSenderOn: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
+		expect(afterSenderOn.senderEnabled).toBe(true);
+		expect(afterSenderOn.receiverEnabled).toBe(false);
 
-		// Sender disables the partnership
-		const disabledInvite: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
-		expect(disabledInvite.isActive).toBe(false);
-		expect(disabledInvite.disabledBy).toBe(inviteToSend.sender);
-
-		// Receiver tries to re-enable — should throw
-		try {
-			await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
-			expect.fail('Should have thrown error when other org tries to re-enable');
-		} catch (error) {
-			expect(error).toBeDefined();
-			expect((error as Error).message).toContain('Only the organization that disabled');
-		}
-
-		// Sender re-enables — should succeed
-		const reenabledInvite: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
-		expect(reenabledInvite.isActive).toBe(true);
-		expect(reenabledInvite.disabledBy).toBeNull();
+		// Sender disables sharing
+		const afterSenderOff: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
+		expect(afterSenderOff.senderEnabled).toBe(false);
+		expect(afterSenderOff.receiverEnabled).toBe(false);
 	});
 
-	// Bug 3: Atomic toggle — both mailboxes must be consistent
+	// Per-org toggle: receiver toggle only flips receiverEnabled
+	it('should only flip receiverEnabled when receiver toggles', async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+		});
+
+		const inviteToSend = generateInvites(1)[0];
+		const createdInvite: OrgInvite = await stub.send(
+			inviteToSend.sender,
+			inviteToSend.receiver,
+			inviteToSend.message
+		);
+
+		await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+
+		// Receiver enables sharing
+		const afterReceiverOn: OrgInvite = await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
+		expect(afterReceiverOn.senderEnabled).toBe(false);
+		expect(afterReceiverOn.receiverEnabled).toBe(true);
+
+		// Receiver disables sharing
+		const afterReceiverOff: OrgInvite = await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
+		expect(afterReceiverOff.senderEnabled).toBe(false);
+		expect(afterReceiverOff.receiverEnabled).toBe(false);
+	});
+
+	// Per-org toggle: both orgs toggle independently
+	it('should allow sender and receiver to toggle independently', async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+		});
+
+		const inviteToSend = generateInvites(1)[0];
+		const createdInvite: OrgInvite = await stub.send(
+			inviteToSend.sender,
+			inviteToSend.receiver,
+			inviteToSend.message
+		);
+
+		await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
+
+		// Sender enables
+		await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
+		// Receiver enables
+		const bothOn: OrgInvite = await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
+		expect(bothOn.senderEnabled).toBe(true);
+		expect(bothOn.receiverEnabled).toBe(true);
+
+		// Sender disables — receiver stays on
+		const senderOff: OrgInvite = await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
+		expect(senderOff.senderEnabled).toBe(false);
+		expect(senderOff.receiverEnabled).toBe(true);
+
+		// Receiver disables
+		const bothOff: OrgInvite = await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
+		expect(bothOff.senderEnabled).toBe(false);
+		expect(bothOff.receiverEnabled).toBe(false);
+	});
+
+	// Atomic toggle — both mailboxes must be consistent for per-org fields
 	it('should handle toggle atomically across both mailboxes', async () => {
 		const id = env.ORG_MATCHMAKING.idFromName('default');
 		const stub = env.ORG_MATCHMAKING.get(id);
 
-		// clear the storage
 		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
 			await state.storage.deleteAll();
 		});
@@ -767,31 +840,30 @@ describe('organization matchmaking worker', () => {
 			inviteToSend.message
 		);
 
-		// Accept the invite
 		await stub.respond(inviteToSend.receiver, createdInvite.id, OrgInviteStatusSchema.enum.accepted);
 
-		// Toggle ON
+		// Sender toggles ON
 		await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
 
 		// Verify both mailboxes are consistent
 		const senderInvite: OrgInvite = await stub.read(inviteToSend.sender, createdInvite.id);
 		const receiverInvite: OrgInvite = await stub.read(inviteToSend.receiver, createdInvite.id);
 
-		expect(senderInvite.isActive).toBe(receiverInvite.isActive);
-		expect(senderInvite.disabledBy).toBe(receiverInvite.disabledBy);
-		expect(senderInvite.isActive).toBe(true);
-		expect(senderInvite.disabledBy).toBeNull();
+		expect(senderInvite.senderEnabled).toBe(receiverInvite.senderEnabled);
+		expect(senderInvite.receiverEnabled).toBe(receiverInvite.receiverEnabled);
+		expect(senderInvite.senderEnabled).toBe(true);
+		expect(senderInvite.receiverEnabled).toBe(false);
 
-		// Toggle OFF
-		await stub.togglePartnership(inviteToSend.sender, createdInvite.id);
+		// Receiver toggles ON
+		await stub.togglePartnership(inviteToSend.receiver, createdInvite.id);
 
-		const senderAfterOff: OrgInvite = await stub.read(inviteToSend.sender, createdInvite.id);
-		const receiverAfterOff: OrgInvite = await stub.read(inviteToSend.receiver, createdInvite.id);
+		const senderAfter: OrgInvite = await stub.read(inviteToSend.sender, createdInvite.id);
+		const receiverAfter: OrgInvite = await stub.read(inviteToSend.receiver, createdInvite.id);
 
-		expect(senderAfterOff.isActive).toBe(receiverAfterOff.isActive);
-		expect(senderAfterOff.disabledBy).toBe(receiverAfterOff.disabledBy);
-		expect(senderAfterOff.isActive).toBe(false);
-		expect(senderAfterOff.disabledBy).toBe(inviteToSend.sender);
+		expect(senderAfter.senderEnabled).toBe(receiverAfter.senderEnabled);
+		expect(senderAfter.receiverEnabled).toBe(receiverAfter.receiverEnabled);
+		expect(senderAfter.senderEnabled).toBe(true);
+		expect(senderAfter.receiverEnabled).toBe(true);
 	});
 });
 
@@ -836,7 +908,8 @@ describe('Invite Management', () => {
 			expect(invite.receiver).toBe(inviteToSend.receiver);
 			expect(invite.message).toBe(inviteToSend.message);
 			expect(invite.status).toBe('pending');
-			expect(invite.isActive).toBe(false);
+			expect(invite.senderEnabled).toBe(false);
+			expect(invite.receiverEnabled).toBe(false);
 		});
 
 		it('should return error when token is missing', async () => {
@@ -1121,6 +1194,259 @@ describe('Invite Management', () => {
 		});
 	});
 
+	describe('SpiceDB calls on toggle', () => {
+		it('should call addPartnerToOrg(sender, receiver) when sender enables', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send invite as sender
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			expect(sendResponse.success).toBe(true);
+			const invite = sendResponse.data as OrgInvite;
+
+			// Accept as receiver
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Spy on SpiceDB calls
+			const addSpy = vi.fn(async () => {});
+			const deleteSpy = vi.fn(async () => {});
+			env.AUTHZED.addPartnerToOrg = addSpy;
+			env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+			// Sender toggles ON
+			mockGetUser(senderUser);
+			const toggleResponse = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			expect(toggleResponse.success).toBe(true);
+
+			// Only addPartnerToOrg(sender, receiver) called
+			expect(addSpy).toHaveBeenCalledOnce();
+			expect(addSpy).toHaveBeenCalledWith('default', receiverOrg);
+			expect(deleteSpy).not.toHaveBeenCalled();
+		});
+
+		it('should call addPartnerToOrg(receiver, sender) when receiver enables', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send and accept
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Spy on SpiceDB calls
+			const addSpy = vi.fn(async () => {});
+			const deleteSpy = vi.fn(async () => {});
+			env.AUTHZED.addPartnerToOrg = addSpy;
+			env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+			// Receiver toggles ON
+			mockGetUser(receiverUser);
+			const toggleResponse = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			expect(toggleResponse.success).toBe(true);
+
+			// Only addPartnerToOrg(receiver, sender) called
+			expect(addSpy).toHaveBeenCalledOnce();
+			expect(addSpy).toHaveBeenCalledWith(receiverOrg, 'default');
+			expect(deleteSpy).not.toHaveBeenCalled();
+		});
+
+		it('should call deletePartnerInOrg when sender disables', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send and accept
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Sender toggles ON first
+			env.AUTHZED.addPartnerToOrg = async () => {};
+			env.AUTHZED.deletePartnerInOrg = async () => {};
+			mockGetUser(senderUser);
+			await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+
+			// Now spy and toggle OFF
+			const addSpy = vi.fn(async () => {});
+			const deleteSpy = vi.fn(async () => {});
+			env.AUTHZED.addPartnerToOrg = addSpy;
+			env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+			const toggleResponse = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			expect(toggleResponse.success).toBe(true);
+
+			expect(deleteSpy).toHaveBeenCalledOnce();
+			expect(deleteSpy).toHaveBeenCalledWith('default', receiverOrg);
+			expect(addSpy).not.toHaveBeenCalled();
+		});
+
+		it('should rollback DO state when SpiceDB addPartnerToOrg fails', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send and accept
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Make SpiceDB throw on addPartnerToOrg
+			env.AUTHZED.addPartnerToOrg = async () => {
+				throw new Error('SpiceDB unavailable');
+			};
+			env.AUTHZED.deletePartnerInOrg = async () => {};
+
+			// Sender toggles ON — SpiceDB fails, DO should rollback
+			mockGetUser(senderUser);
+			const toggleResponse = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			expect(toggleResponse.success).toBe(false);
+
+			// Verify DO state was reverted — both flags should be back to false
+			const id = env.ORG_MATCHMAKING.idFromName('default');
+			const stub = env.ORG_MATCHMAKING.get(id);
+			const afterRollback = await stub.read(senderUser.orgId, invite.id);
+			expect(afterRollback.senderEnabled).toBe(false);
+			expect(afterRollback.receiverEnabled).toBe(false);
+		});
+
+		it('should call deletePartnerInOrg(receiver, sender) when receiver disables', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send and accept
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Receiver toggles ON first
+			env.AUTHZED.addPartnerToOrg = async () => {};
+			env.AUTHZED.deletePartnerInOrg = async () => {};
+			mockGetUser(receiverUser);
+			await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+
+			// Now spy and toggle OFF
+			const addSpy = vi.fn(async () => {});
+			const deleteSpy = vi.fn(async () => {});
+			env.AUTHZED.addPartnerToOrg = addSpy;
+			env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+			const toggleResponse = await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+			expect(toggleResponse.success).toBe(true);
+
+			// deletePartnerInOrg(receiver, sender) — receiver's data no longer shared with sender
+			expect(deleteSpy).toHaveBeenCalledOnce();
+			expect(deleteSpy).toHaveBeenCalledWith(receiverOrg, 'default');
+			expect(addSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not call addPartnerToOrg on accept', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			// Spy on SpiceDB calls
+			const addSpy = vi.fn(async () => {});
+			env.AUTHZED.addPartnerToOrg = addSpy;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+
+			const acceptResponse = await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+			expect(acceptResponse.success).toBe(true);
+
+			// No SpiceDB calls on accept
+			expect(addSpy).not.toHaveBeenCalled();
+		});
+
+		it('should unconditionally clean up both directions on decline', async () => {
+			const worker = SELF;
+			const senderUser = createMockUser('default');
+			const receiverOrg = 'test-receiver-org-1';
+
+			await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+			// Send, accept, then sender enables
+			mockGetUser(senderUser);
+			env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+			const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+			const invite = sendResponse.data as OrgInvite;
+
+			const receiverUser = createMockUser(receiverOrg);
+			await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+			mockGetUser(receiverUser);
+			await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+			// Sender enables (only sender direction open)
+			env.AUTHZED.addPartnerToOrg = async () => {};
+			env.AUTHZED.deletePartnerInOrg = async () => {};
+			mockGetUser(senderUser);
+			await worker.togglePartnership(invite.id, { cfToken: 'valid-token' });
+
+			// Now spy and decline
+			const deleteSpy = vi.fn(async () => {});
+			env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+			mockGetUser(senderUser);
+			const declineResponse = await worker.declineInvite(invite.id, { cfToken: 'valid-token' });
+			expect(declineResponse.success).toBe(true);
+
+			// Both directions cleaned up unconditionally (deletePartnerInOrg is idempotent)
+			expect(deleteSpy).toHaveBeenCalledTimes(2);
+			expect(deleteSpy).toHaveBeenCalledWith('default', receiverOrg);
+			expect(deleteSpy).toHaveBeenCalledWith(receiverOrg, 'default');
+		});
+	});
+
 	describe('listInvites', () => {
 		it('should list all invites for an organization', async () => {
 			const worker = SELF;
@@ -1153,7 +1479,8 @@ describe('Invite Management', () => {
 				expect(listedInvites[i].receiver).toBe(invites[i].receiver);
 				expect(listedInvites[i].message).toBe(invites[i].message);
 				expect(listedInvites[i].status).toBe('pending');
-				expect(listedInvites[i].isActive).toBe(false);
+				expect(listedInvites[i].senderEnabled).toBe(false);
+				expect(listedInvites[i].receiverEnabled).toBe(false);
 			}
 		});
 
@@ -1430,5 +1757,623 @@ describe('Data Custodian Partner Update Restrictions', () => {
 
 		// Cleanup
 		await env.AUTHZED.deleteAdminFromOrg(testOrgId, adminUser.userId);
+	});
+});
+
+describe('DO storage migration (old-format data)', () => {
+	it('should migrate old-format isActive/disabledBy data on list and read', async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		const oldFormatInvite = {
+			id: 'old-format-invite-1',
+			status: 'accepted',
+			sender: 'org-alpha',
+			receiver: 'org-beta',
+			message: 'legacy invite',
+			isActive: true,
+			disabledBy: null,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		};
+
+		// Seed old-format data directly into DO storage
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+			await state.storage.put('org-alpha', [oldFormatInvite]);
+			await state.storage.put('org-beta', [oldFormatInvite]);
+		});
+
+		// list() should return migrated data
+		const listed = await stub.list('org-alpha');
+		expect(listed).toHaveLength(1);
+		expect(listed[0].senderEnabled).toBe(true);
+		expect(listed[0].receiverEnabled).toBe(true);
+		expect(listed[0]).not.toHaveProperty('isActive');
+		expect(listed[0]).not.toHaveProperty('disabledBy');
+
+		// read() should return migrated data
+		const read = await stub.read('org-alpha', 'old-format-invite-1');
+		expect(read.senderEnabled).toBe(true);
+		expect(read.receiverEnabled).toBe(true);
+	});
+
+	it('should migrate old-format isActive: false to both disabled', async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		const oldFormatInvite = {
+			id: 'old-format-invite-2',
+			status: 'accepted',
+			sender: 'org-alpha',
+			receiver: 'org-beta',
+			message: 'disabled legacy invite',
+			isActive: false,
+			disabledBy: 'org-alpha',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		};
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+			await state.storage.put('org-alpha', [oldFormatInvite]);
+		});
+
+		const listed = await stub.list('org-alpha');
+		expect(listed).toHaveLength(1);
+		expect(listed[0].senderEnabled).toBe(false);
+		expect(listed[0].receiverEnabled).toBe(false);
+	});
+});
+
+describe('Old-format data: write operations and SpiceDB integration', () => {
+	const SENDER = 'org-sender';
+	const RECEIVER = 'org-receiver';
+
+	beforeEach(async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+		});
+
+		delete (env.AUTHZED as Record<string, unknown>).canUpdateOrgPartnersInOrg;
+	});
+
+	// Test 1: Sender toggles off on isActive: true
+	it('sender toggles off on isActive: true → deletePartnerInOrg(sender, receiver)', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const invite = createOldFormatInvite({ id: 'old-1', sender: SENDER, receiver: RECEIVER, isActive: true });
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const addSpy = vi.fn(async () => {});
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.togglePartnership('old-1', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const toggled = (response as { success: true; data: OrgInvite }).data;
+		expect(toggled.senderEnabled).toBe(false);
+		expect(toggled.receiverEnabled).toBe(true);
+
+		expect(deleteSpy).toHaveBeenCalledOnce();
+		expect(deleteSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+		expect(addSpy).not.toHaveBeenCalled();
+	});
+
+	// Test 2: Receiver toggles off on isActive: true
+	it('receiver toggles off on isActive: true → deletePartnerInOrg(receiver, sender)', async () => {
+		const worker = SELF;
+		const receiverUser = createMockUser(RECEIVER);
+		const invite = createOldFormatInvite({ id: 'old-2', sender: SENDER, receiver: RECEIVER, isActive: true });
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+		mockGetUser(receiverUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const addSpy = vi.fn(async () => {});
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.togglePartnership('old-2', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const toggled = (response as { success: true; data: OrgInvite }).data;
+		expect(toggled.senderEnabled).toBe(true);
+		expect(toggled.receiverEnabled).toBe(false);
+
+		expect(deleteSpy).toHaveBeenCalledOnce();
+		expect(deleteSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+		expect(addSpy).not.toHaveBeenCalled();
+	});
+
+	// Test 3: Sender toggles on from isActive: false, disabledBy: sender
+	it('sender toggles on from isActive: false, disabledBy: sender → addPartnerToOrg(sender, receiver)', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const invite = createOldFormatInvite({
+			id: 'old-3',
+			sender: SENDER,
+			receiver: RECEIVER,
+			isActive: false,
+			disabledBy: SENDER,
+		});
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const addSpy = vi.fn(async () => {});
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.togglePartnership('old-3', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const toggled = (response as { success: true; data: OrgInvite }).data;
+		expect(toggled.senderEnabled).toBe(true);
+		expect(toggled.receiverEnabled).toBe(false);
+
+		expect(addSpy).toHaveBeenCalledOnce();
+		expect(addSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+		expect(deleteSpy).not.toHaveBeenCalled();
+	});
+
+	// Test 4: Tug-of-war liberation — receiver toggles on from isActive: false, disabledBy: sender
+	it('tug-of-war liberation: receiver toggles on from isActive: false, disabledBy: sender', async () => {
+		const worker = SELF;
+		const receiverUser = createMockUser(RECEIVER);
+		const invite = createOldFormatInvite({
+			id: 'old-4',
+			sender: SENDER,
+			receiver: RECEIVER,
+			isActive: false,
+			disabledBy: SENDER,
+		});
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+		mockGetUser(receiverUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const addSpy = vi.fn(async () => {});
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.togglePartnership('old-4', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const toggled = (response as { success: true; data: OrgInvite }).data;
+		expect(toggled.receiverEnabled).toBe(true);
+
+		expect(addSpy).toHaveBeenCalledOnce();
+		expect(addSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+		expect(deleteSpy).not.toHaveBeenCalled();
+	});
+
+	// Test 5: Decline on isActive: true triggers bidirectional cleanup
+	it('decline on isActive: true triggers bidirectional SpiceDB cleanup', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const invite = createOldFormatInvite({ id: 'old-5', sender: SENDER, receiver: RECEIVER, isActive: true });
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.declineInvite('old-5', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const declined = (response as { success: true; data: OrgInvite }).data;
+		expect(declined.status).toBe('declined');
+
+		expect(deleteSpy).toHaveBeenCalledTimes(2);
+		expect(deleteSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+		expect(deleteSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+
+		// Verify mailboxes are empty
+		const senderList = await stub.list(SENDER);
+		const receiverList = await stub.list(RECEIVER);
+		expect(senderList).toHaveLength(0);
+		expect(receiverList).toHaveLength(0);
+	});
+
+	// Test 6: Decline on isActive: false still cleans up (idempotent)
+	it('decline on isActive: false still cleans up both SpiceDB directions', async () => {
+		const worker = SELF;
+		const receiverUser = createMockUser(RECEIVER);
+		const invite = createOldFormatInvite({
+			id: 'old-6',
+			sender: SENDER,
+			receiver: RECEIVER,
+			isActive: false,
+			disabledBy: SENDER,
+		});
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+		mockGetUser(receiverUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		const response = await worker.declineInvite('old-6', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		expect(deleteSpy).toHaveBeenCalledTimes(2);
+		expect(deleteSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+		expect(deleteSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+
+		const senderList = await stub.list(SENDER);
+		const receiverList = await stub.list(RECEIVER);
+		expect(senderList).toHaveLength(0);
+		expect(receiverList).toHaveLength(0);
+	});
+
+	// Test 7: Mixed mailbox — old + new format invites coexist
+	it('mixed mailbox: old-format invite toggled correctly, new-format invite untouched', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+
+		const oldInvite = createOldFormatInvite({ id: 'old-7', sender: SENDER, receiver: RECEIVER, isActive: true });
+		const newInvite: OrgInvite = {
+			id: 'new-7',
+			status: 'accepted',
+			sender: SENDER,
+			receiver: 'org-other',
+			message: 'new format',
+			senderEnabled: true,
+			receiverEnabled: false,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		};
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [oldInvite, newInvite]);
+			await state.storage.put(RECEIVER, [oldInvite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		const addSpy = vi.fn(async () => {});
+		const deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		// Toggle the old invite (sender toggles off from migrated isActive: true)
+		const response = await worker.togglePartnership('old-7', { cfToken: 'valid-token' });
+		expect(response.success).toBe(true);
+
+		const toggled = (response as { success: true; data: OrgInvite }).data;
+		expect(toggled.senderEnabled).toBe(false);
+		expect(toggled.receiverEnabled).toBe(true);
+
+		// Verify the new-format invite is untouched
+		const afterList = await stub.list(SENDER);
+		const untouched = afterList.find((i) => i.id === 'new-7');
+		expect(untouched).toBeDefined();
+		expect(untouched!.senderEnabled).toBe(true);
+		expect(untouched!.receiverEnabled).toBe(false);
+	});
+
+	// Test 8: Sequential toggle round-trip on old data
+	it('sequential toggle round-trip on old data produces correct SpiceDB calls', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const receiverUser = createMockUser(RECEIVER);
+		const invite = createOldFormatInvite({ id: 'old-8', sender: SENDER, receiver: RECEIVER, isActive: true });
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		// Step 1: Sender toggles OFF (from migrated true,true → false,true)
+		let addSpy = vi.fn(async () => {});
+		let deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		mockGetUser(senderUser);
+		const step1 = await worker.togglePartnership('old-8', { cfToken: 'valid-token' });
+		expect(step1.success).toBe(true);
+		expect((step1 as { success: true; data: OrgInvite }).data.senderEnabled).toBe(false);
+		expect((step1 as { success: true; data: OrgInvite }).data.receiverEnabled).toBe(true);
+		expect(deleteSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+
+		// Step 2: Receiver toggles OFF (false,true → false,false)
+		addSpy = vi.fn(async () => {});
+		deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		mockGetUser(receiverUser);
+		const step2 = await worker.togglePartnership('old-8', { cfToken: 'valid-token' });
+		expect(step2.success).toBe(true);
+		expect((step2 as { success: true; data: OrgInvite }).data.senderEnabled).toBe(false);
+		expect((step2 as { success: true; data: OrgInvite }).data.receiverEnabled).toBe(false);
+		expect(deleteSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+
+		// Step 3: Sender toggles ON (false,false → true,false)
+		addSpy = vi.fn(async () => {});
+		deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		mockGetUser(senderUser);
+		const step3 = await worker.togglePartnership('old-8', { cfToken: 'valid-token' });
+		expect(step3.success).toBe(true);
+		expect((step3 as { success: true; data: OrgInvite }).data.senderEnabled).toBe(true);
+		expect((step3 as { success: true; data: OrgInvite }).data.receiverEnabled).toBe(false);
+		expect(addSpy).toHaveBeenCalledWith(SENDER, RECEIVER);
+
+		// Step 4: Receiver toggles ON (true,false → true,true)
+		addSpy = vi.fn(async () => {});
+		deleteSpy = vi.fn(async () => {});
+		env.AUTHZED.addPartnerToOrg = addSpy;
+		env.AUTHZED.deletePartnerInOrg = deleteSpy;
+
+		mockGetUser(receiverUser);
+		const step4 = await worker.togglePartnership('old-8', { cfToken: 'valid-token' });
+		expect(step4.success).toBe(true);
+		expect((step4 as { success: true; data: OrgInvite }).data.senderEnabled).toBe(true);
+		expect((step4 as { success: true; data: OrgInvite }).data.receiverEnabled).toBe(true);
+		expect(addSpy).toHaveBeenCalledWith(RECEIVER, SENDER);
+
+		// Verify final state via DO read
+		const final = await stub.read(SENDER, 'old-8');
+		expect(final.senderEnabled).toBe(true);
+		expect(final.receiverEnabled).toBe(true);
+	});
+
+	// Test 9: SpiceDB rollback on old isActive: false data
+	it('SpiceDB add failure on old isActive: false data rolls back senderEnabled', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const invite = createOldFormatInvite({
+			id: 'old-9',
+			sender: SENDER,
+			receiver: RECEIVER,
+			isActive: false,
+			disabledBy: SENDER,
+		});
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		env.AUTHZED.addPartnerToOrg = async () => {
+			throw new Error('SpiceDB unavailable');
+		};
+		env.AUTHZED.deletePartnerInOrg = async () => {};
+
+		const response = await worker.togglePartnership('old-9', { cfToken: 'valid-token' });
+		expect(response.success).toBe(false);
+
+		// DO state should be reverted — senderEnabled back to false
+		const afterRollback = await stub.read(SENDER, 'old-9');
+		expect(afterRollback.senderEnabled).toBe(false);
+		expect(afterRollback.receiverEnabled).toBe(false);
+	});
+
+	// Test 10: SpiceDB rollback on old isActive: true data
+	it('SpiceDB delete failure on old isActive: true data rolls back senderEnabled', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser(SENDER);
+		const invite = createOldFormatInvite({ id: 'old-10', sender: SENDER, receiver: RECEIVER, isActive: true });
+
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.put(SENDER, [invite]);
+			await state.storage.put(RECEIVER, [invite]);
+		});
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+
+		env.AUTHZED.addPartnerToOrg = async () => {};
+		env.AUTHZED.deletePartnerInOrg = async () => {
+			throw new Error('SpiceDB unavailable');
+		};
+
+		// Sender toggles OFF on migrated isActive: true — SpiceDB delete fails
+		const response = await worker.togglePartnership('old-10', { cfToken: 'valid-token' });
+		expect(response.success).toBe(false);
+
+		// DO state should be reverted — senderEnabled back to true
+		const afterRollback = await stub.read(SENDER, 'old-10');
+		expect(afterRollback.senderEnabled).toBe(true);
+		expect(afterRollback.receiverEnabled).toBe(true);
+	});
+});
+
+describe('declineInvite SpiceDB fault tolerance', () => {
+	beforeEach(async () => {
+		const id = env.ORG_MATCHMAKING.idFromName('default');
+		const stub = env.ORG_MATCHMAKING.get(id);
+
+		await runInDurableObject(stub, async (_: unknown, state: DurableObjectState) => {
+			await state.storage.deleteAll();
+		});
+
+		delete (env.AUTHZED as Record<string, unknown>).canUpdateOrgPartnersInOrg;
+	});
+
+	it('should return success even when SpiceDB deletePartnerInOrg throws', async () => {
+		const worker = SELF;
+		const senderUser = createMockUser('default');
+		const receiverOrg = 'test-receiver-org-1';
+
+		await env.AUTHZED.addUserToOrg(senderUser.orgId, senderUser.userId);
+
+		// Send invite
+		mockGetUser(senderUser);
+		env.AUTHZED.canUpdateOrgPartnersInOrg = async () => true;
+		const sendResponse = await worker.sendInvite(receiverOrg, { cfToken: 'valid-token' }, 'test');
+		expect(sendResponse.success).toBe(true);
+		const invite = sendResponse.data as OrgInvite;
+
+		// Accept as receiver
+		const receiverUser = createMockUser(receiverOrg);
+		await env.AUTHZED.addUserToOrg(receiverUser.orgId, receiverUser.userId);
+		mockGetUser(receiverUser);
+		await worker.acceptInvite(invite.id, { cfToken: 'valid-token' });
+
+		// Make SpiceDB throw on deletePartnerInOrg
+		env.AUTHZED.deletePartnerInOrg = async () => {
+			throw new Error('SpiceDB unavailable');
+		};
+
+		// Decline should still succeed (DO deletion is source of truth)
+		mockGetUser(receiverUser);
+		const declineResponse = await worker.declineInvite(invite.id, { cfToken: 'valid-token' });
+		expect(declineResponse.success).toBe(true);
+		if (declineResponse.success) {
+			const declinedInvite = declineResponse.data as OrgInvite;
+			expect(declinedInvite.status).toBe('declined');
+		}
+	});
+});
+
+describe('OrgInviteStoredSchema migration', () => {
+	const base = {
+		id: 'test-id',
+		status: 'accepted' as const,
+		sender: 'org-a',
+		receiver: 'org-b',
+		message: 'hello',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+
+	it('should migrate old format isActive: true to both enabled', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base, isActive: true });
+		expect(result.senderEnabled).toBe(true);
+		expect(result.receiverEnabled).toBe(true);
+	});
+
+	it('should migrate old format isActive: false to both disabled', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base, isActive: false });
+		expect(result.senderEnabled).toBe(false);
+		expect(result.receiverEnabled).toBe(false);
+	});
+
+	it('should pass through new format values unchanged', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base, senderEnabled: true, receiverEnabled: false });
+		expect(result.senderEnabled).toBe(true);
+		expect(result.receiverEnabled).toBe(false);
+	});
+
+	it('should default missing field to false in partial migration', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base, senderEnabled: true });
+		expect(result.senderEnabled).toBe(true);
+		expect(result.receiverEnabled).toBe(false);
+	});
+
+	it('should default to both disabled when no toggle fields present', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base });
+		expect(result.senderEnabled).toBe(false);
+		expect(result.receiverEnabled).toBe(false);
+	});
+
+	it('should prefer new fields over isActive when both are present', () => {
+		const result = OrgInviteStoredSchema.parse({
+			...base,
+			isActive: true,
+			senderEnabled: false,
+			receiverEnabled: false,
+		});
+		expect(result.senderEnabled).toBe(false);
+		expect(result.receiverEnabled).toBe(false);
+	});
+
+	it('should discard disabledBy even when isActive is true', () => {
+		const result = OrgInviteStoredSchema.parse({ ...base, isActive: true, disabledBy: 'org-x' });
+		expect(result.senderEnabled).toBe(true);
+		expect(result.receiverEnabled).toBe(true);
+		expect(result).not.toHaveProperty('disabledBy');
 	});
 });

--- a/packages/schemas/src/domains/organization/invites.ts
+++ b/packages/schemas/src/domains/organization/invites.ts
@@ -22,29 +22,75 @@ export const OrgInviteInputSchema = z.object({
     sender: OrgIdSchema,
     receiver: OrgIdSchema,
     message: safeMessage(),
-    isActive: z.boolean(),
-    disabledBy: OrgIdSchema.nullable().default(null),
+    senderEnabled: z.boolean(),
+    receiverEnabled: z.boolean(),
     createdAt: timestamp(),
     updatedAt: timestamp(),
 });
 
 // Lenient schema for parsing stored data (allows timestamps beyond 10 years for old data)
-export const OrgInviteStoredSchema = z.object({
-    id: z.string().min(1, 'Invite ID is required').max(100, 'Invite ID too long'),
-    status: OrgInviteStatusSchema,
-    sender: OrgIdSchema,
-    receiver: OrgIdSchema,
-    message: z.string().max(1000), // Lenient message validation
-    isActive: z.boolean(),
-    disabledBy: z.string().min(1).max(100).nullable().optional().default(null),
-    createdAt: z.number().int().positive(),
-    updatedAt: z.number().int().positive(),
-});
+// Accepts both old (isActive/disabledBy) and new (senderEnabled/receiverEnabled) fields,
+// normalizing old data via transform.
+export const OrgInviteStoredSchema = z
+    .object({
+        id: z.string().min(1, 'Invite ID is required').max(100, 'Invite ID too long'),
+        status: OrgInviteStatusSchema,
+        sender: OrgIdSchema,
+        receiver: OrgIdSchema,
+        message: z.string().max(1000), // Lenient message validation
+        // New fields
+        senderEnabled: z.boolean().optional(),
+        receiverEnabled: z.boolean().optional(),
+        // Old fields (for backward compat)
+        isActive: z.boolean().optional(),
+        disabledBy: z.string().min(1).max(100).nullable().optional(),
+        createdAt: z.number().int().positive(),
+        updatedAt: z.number().int().positive(),
+    })
+    // Migration semantics:
+    // - `disabledBy` is intentionally discarded — the new per-org model has no "who disabled" concept.
+    // - `isActive: true`  → both senderEnabled and receiverEnabled set to true.
+    // - `isActive: false` → both senderEnabled and receiverEnabled set to false.
+    // - Behavioral impact: orgs previously blocked by tug-of-war can now independently toggle
+    //   their sharing flag. Old data is normalized on read; no backfill write is performed.
+    .transform((data) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { isActive, disabledBy, ...rest } = data;
+        // Both new fields present — use as-is
+        if (rest.senderEnabled !== undefined && rest.receiverEnabled !== undefined) {
+            return { ...rest, senderEnabled: rest.senderEnabled, receiverEnabled: rest.receiverEnabled };
+        }
+        // Partial migration: one new field present, other missing
+        if (rest.senderEnabled !== undefined || rest.receiverEnabled !== undefined) {
+            return {
+                ...rest,
+                senderEnabled: rest.senderEnabled ?? false,
+                receiverEnabled: rest.receiverEnabled ?? false,
+            };
+        }
+        // Full old-data migration
+        const enabled = isActive ?? false;
+        return { ...rest, senderEnabled: enabled, receiverEnabled: enabled };
+    });
 
 // Backwards compatibility: OrgInviteSchema points to the input schema
 export const OrgInviteSchema = OrgInviteInputSchema;
 
 export type OrgInvite = z.infer<typeof OrgInviteInputSchema>;
+
+/**
+ * Parse a single stored invite through the migration transform.
+ * Centralises the OrgInviteStoredSchema → OrgInvite cast so consumers
+ * don't carry the `as OrgInvite` coupling themselves.
+ */
+export function parseStoredInvite(data: unknown): OrgInvite {
+    return OrgInviteStoredSchema.parse(data) as OrgInvite;
+}
+
+/** Array variant of {@link parseStoredInvite}. */
+export function parseStoredInvites(data: unknown): OrgInvite[] {
+    return OrgInviteStoredSchema.array().parse(data) as OrgInvite[];
+}
 
 // Response schema for API boundaries (single invite or array)
 export const OrgInviteResponseSchema = createResponseSchema(z.union([OrgInviteSchema, OrgInviteSchema.array()]));


### PR DESCRIPTION
## Replace bidirectional partnership toggle with independent per-org data sharing flags

Replace the single isActive/disabledBy partnership model with independent
senderEnabled/receiverEnabled flags, giving each org control over their
own data-sharing direction.

The old model created an asymmetric power dynamic — whoever disabled the
partnership held a "lock" the other couldn't release. The new model treats
data-sharing as a unidirectional consent: each org independently controls
whether their data is visible to the partner. This maps cleanly to the
SpiceDB permission model where addPartnerToOrg(sharer, reader) is
directional.

### Schema Changes
- Replace `isActive`/`disabledBy` fields with `senderEnabled`/`receiverEnabled` flags
- Add `parseStoredInvite`/`parseStoredInvites` functions for migration
- `OrgInviteStoredSchema` handles backward-compatible transformation of old data

### Durable Object Updates
- `togglePartnership` now flips only the caller's own sharing flag (sender toggles `senderEnabled`, receiver toggles `receiverEnabled`)
- Add `setPartnershipFlags` method for atomic rollback scenarios
- Remove tug-of-war validation logic
- Mailbox parsing migrates old format data on read

### Worker API Changes
- Unidirectional SpiceDB calls: `addPartnerToOrg(sharer, reader)` when org enables sharing
- SpiceDB rollback on failure preserves partner's flag while reverting caller's change
- `acceptInvite` no longer writes SpiceDB permissions (sharing starts disabled)
- `declineInvite` unconditionally cleans up both directions with fault tolerance

### UI Improvements
- Partnership toggle switch reflects caller's own sharing state
- New `PartnerSharingStatus` component shows whether partner is sharing with you
- Remove tooltip/disabled state for "other org disabled" scenarios
- Simplified toggle logic without tug-of-war complexity

### Testing
- Comprehensive E2E tests for independent toggle behavior
- SpiceDB integration tests for unidirectional permission management
- Migration tests for old-format data compatibility
- Error handling and rollback scenarios