### PR TITLE
fix(channels): show all field errors in validation format

### DIFF
--- a/apps/catalyst-ui-worker/app/actions/channels.ts
+++ b/apps/catalyst-ui-worker/app/actions/channels.ts
@@ -1,22 +1,14 @@
 'use server';
+import { z } from 'zod';
 import { getRegistrar, DataChannelInputSchema, DataChannel } from '@catalyst/schemas';
 import { getCloudflareEnv, getCFAuthorizationToken } from '@/app/lib/server-utils';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function formatZodError(error: { issues: any[] }): string {
-    // Prioritize name field errors as they're most user-facing
-    const nameErrors = error.issues
-        .filter((issue) => issue.path?.includes('name'))
-        .map((issue) => issue.message as string);
-
-    if (nameErrors.length > 0) {
-        return nameErrors[0];
+function formatZodError(error: z.ZodError): string {
+    if (!error) {
+        return 'Unknown validation error';
     }
-
-    // Format other validation errors
-    const fieldErrors = error.issues.map((err) => `${err.path?.join('.') ?? ''}: ${err.message}`).join(', ');
-
-    return `Invalid data channel - ${fieldErrors || 'Unknown validation error'}`;
+    const fieldErrors = error.issues.map((err) => `[field:${err.path?.join('.') ?? ''}](${err.message})`).join(' + ');
+    return `[ParsingError] DataChannel: ${fieldErrors || 'Unknown validation error'}`;
 }
 
 export async function createDataChannel(formData: FormData) {


### PR DESCRIPTION
### TL;DR

Improved error formatting for data channel validation failures with better type safety and structured error messages.

### What changed?

- Updated `formatZodError` function to accept proper `z.ZodError` type instead of generic object
- Removed prioritization logic for name field errors
- Changed error message format to use structured syntax with field names and messages
- Added null check for error parameter with fallback message

### How to test?

1. Submit invalid data channel form data to trigger validation errors
2. Verify error messages now display in the format `[ParsingError] DataChannel: [field:fieldName](error message)`
3. Test with various invalid field combinations to ensure all validation errors are properly formatted

### Why make this change?

Enhances type safety by using the proper Zod error type and provides more consistent, structured error messaging that's easier to parse and display to users.